### PR TITLE
feat: add multiple mcp clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,12 @@ MCPM will support managing MCP servers for the following clients:
 - Claude Desktop (Anthropic)
 - Cursor
 - Windsurf
-- Additional clients coming soon...
+- Cline
+- Continue
+- Goose
+- 5ire
+- Roo Code
+- More clients coming soon...
 
 ## Command Line Interface (CLI)
 
@@ -122,7 +127,7 @@ mcpm.sh/
    ```
    # Either use the installed package
    mcpm --help
-   
+
    # Or use the development script
    ./test_cli.py --help
    ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
     "pydantic>=2.5.1",
     "jsonschema>=4.17.0",
     "mcp>=1.6.0",
+    "ruamel-yaml>=0.18.10",
 ]
 
 [project.urls]

--- a/src/mcpm/clients/client_registry.py
+++ b/src/mcpm/clients/client_registry.py
@@ -11,7 +11,11 @@ from mcpm.clients.client_config import ClientConfigManager
 
 # Import all client managers
 from mcpm.clients.managers.claude_desktop import ClaudeDesktopManager
+from mcpm.clients.managers.cline import ClineManager, RooCodeManager
+from mcpm.clients.managers.continue_extension import ContinueManager
 from mcpm.clients.managers.cursor import CursorManager
+from mcpm.clients.managers.fiveire import FiveireManager
+from mcpm.clients.managers.goose import GooseClientManager
 from mcpm.clients.managers.windsurf import WindsurfManager
 
 logger = logging.getLogger(__name__)
@@ -31,6 +35,11 @@ class ClientRegistry:
         "claude-desktop": ClaudeDesktopManager(),
         "windsurf": WindsurfManager(),
         "cursor": CursorManager(),
+        "cline": ClineManager(),
+        "continue": ContinueManager(),
+        "goose": GooseClientManager(),
+        "5ire": FiveireManager(),
+        "roo-code": RooCodeManager()
     }
 
     @classmethod

--- a/src/mcpm/clients/managers/cline.py
+++ b/src/mcpm/clients/managers/cline.py
@@ -1,0 +1,132 @@
+import logging
+import os
+from typing import Any, Dict
+
+from mcpm.clients.base import JSONClientManager
+
+logger = logging.getLogger(__name__)
+
+class ClineManager(JSONClientManager):
+    """Manages Cline MCP server configurations"""
+
+    # Client information
+    client_key = "cline"
+    display_name = "Cline"
+    download_url = "https://marketplace.visualstudio.com/items?itemName=saoudrizwan.claude-dev"
+
+    def __init__(self, config_path=None):
+        """Initialize the Cline client manager
+
+        Args:
+            config_path: Optional path to the config file. If not provided, uses default path.
+        """
+        super().__init__()
+
+        if config_path:
+            self.config_path = config_path
+        else:
+            # Set config path based on detected platform
+            if self._system == "Darwin":  # macOS
+                self.config_path = os.path.expanduser("~/Library/Application Support/Code/User/globalStorage/saoudrizwan.claude-dev/settings/cline_mcp_settings.json")
+            elif self._system == "Windows":
+                self.config_path = os.path.join(os.environ.get("APPDATA", ""), "Code", "User", "globalStorage", "saoudrizwan.claude-dev", "settings", "cline_mcp_settings.json")
+            else:
+                # Linux
+                self.config_path = os.path.expanduser("~/.config/Code/User/globalStorage/saoudrizwan.claude-dev/settings/cline_mcp_settings.json")
+
+    def _get_empty_config(self) -> Dict[str, Any]:
+        """Get empty config structure for Cline"""
+        return {self.configure_key_name: {}}
+
+    def disable_server(self, server_name: str) -> bool:
+        """Temporarily disable a server by adding a 'disabled' field to its configuration
+
+        Args:
+            server_name: Name of the server to disable
+
+        Returns:
+            bool: Success or failure
+        """
+        config = self._load_config()
+
+        # Check if the server exists in active servers
+        if self.configure_key_name not in config or server_name not in config[self.configure_key_name]:
+            logger.warning(f"Server '{server_name}' not found in active servers")
+            return False
+
+        # Add disabled field to the server config
+        config[self.configure_key_name][server_name]["disabled"] = True
+
+        return self._save_config(config)
+
+    def enable_server(self, server_name: str) -> bool:
+        """Re-enable a previously disabled server by removing the 'disabled' field
+
+        Args:
+            server_name: Name of the server to enable
+
+        Returns:
+            bool: Success or failure
+        """
+        config = self._load_config()
+
+        # Check if the server exists
+        if self.configure_key_name not in config or server_name not in config[self.configure_key_name]:
+            logger.warning(f"Server '{server_name}' not found in configuration")
+            return False
+
+        # Check if the server is disabled
+        if "disabled" not in config[self.configure_key_name][server_name]:
+            logger.warning(f"Server '{server_name}' is not disabled")
+            return True  # Already enabled, so technically success
+
+        # Remove the disabled field
+        del config[self.configure_key_name][server_name]["disabled"]
+
+        return self._save_config(config)
+
+    def is_server_disabled(self, server_name: str) -> bool:
+        """Check if a server is currently disabled
+
+        Args:
+            server_name: Name of the server to check
+
+        Returns:
+            bool: True if server is disabled, False otherwise
+        """
+        config = self._load_config()
+
+        # Check if the server exists and has the disabled field set to True
+        return (
+            self.configure_key_name in config
+            and server_name in config[self.configure_key_name]
+            and config[self.configure_key_name][server_name].get("disabled", False) is True
+        )
+
+
+class RooCodeManager(ClineManager):
+
+    # Client information
+    client_key = "roo-code"
+    display_name = "Roo Code"
+    download_url = "https://marketplace.visualstudio.com/items?itemName=RooVeterinaryInc.roo-cline"
+
+    def __init__(self, config_path=None):
+        """Initialize the Roo Code client manager
+
+        Args:
+            config_path: Optional path to the config file. If not provided, uses default path.
+        """
+        super().__init__()
+
+        if config_path:
+            self.config_path = config_path
+        else:
+            # Set config path based on detected platform
+            if self._system == "Darwin":  # macOS
+                self.config_path = os.path.expanduser("~/Library/Application Support/Code/User/globalStorage/rooveterinaryinc.roo-cline/settings/mcp_settings.json")
+            elif self._system == "Windows":
+                self.config_path = os.path.join(os.environ.get("APPDATA", ""), "Code", "User", "globalStorage", "rooveterinaryinc.roo-cline", "settings", "mcp_settings.json")
+            else:
+                # Linux
+                self.config_path = os.path.expanduser("~/.config/Code/User/globalStorage/rooveterinaryinc.roo-cline/settings/mcp_settings.json")

--- a/src/mcpm/clients/managers/continue_extension.py
+++ b/src/mcpm/clients/managers/continue_extension.py
@@ -1,0 +1,206 @@
+"""
+Continue MCP server configuration manager
+"""
+
+import logging
+import os
+from typing import Any, Dict, List, Optional
+
+from mcpm.clients.base import YAMLClientManager
+from mcpm.utils.server_config import ServerConfig
+
+logger = logging.getLogger(__name__)
+
+
+class ContinueManager(YAMLClientManager):
+    """Manages Continue MCP server configurations
+
+    Continue uses YAML files for configuration instead of JSON, and has a different
+    structure compared to other clients. This manager handles the Continue-specific
+    configuration format and file locations.
+    """
+
+    # Client information
+    client_key = "continue"
+    display_name = "Continue"
+    download_url = "https://marketplace.visualstudio.com/items?itemName=Continue.continue"
+
+    def __init__(self, config_path=None):
+        """Initialize the Continue client manager
+
+        Args:
+            config_path: Optional path to the config file. If not provided, uses default path.
+        """
+        super().__init__()
+        # Customize YAML handler
+        self.yaml_handler.indent(mapping=2, sequence=4, offset=2)
+        self.yaml_handler.preserve_quotes = True
+
+        if config_path:
+            self.config_path = config_path
+        else:
+            # Set config path based on detected platform
+            if os.name == "Darwin":  # macOS
+                self.config_path = os.path.expanduser("~/.continue/config.yaml")
+            elif os.name == "Windows":
+                self.config_path = os.path.join(os.environ.get("USERPROFILE", ""), ".continue", "config.yaml")
+            else:
+                # Linux
+                self.config_path = os.path.expanduser("~/.continue/config.yaml")
+
+            # Also check for workspace config
+            workspace_config = os.path.join(os.getcwd(), ".continue", "config.yaml")
+            if os.path.exists(workspace_config):
+                # Prefer workspace config if it exists
+                self.config_path = workspace_config
+
+    def _get_empty_config(self) -> Dict[str, Any]:
+        """Get an empty configuration structure for Continue
+
+        Returns:
+            Dict containing the empty configuration structure
+        """
+        return {
+            "name": "Local Assistant",
+            "version": "1.0.0",
+            "schema": "v1",
+            "models": [],
+            "rules": [],
+            "prompts": [],
+            "context": [],
+            "mcpServers": [],
+            "data": []
+        }
+
+    def _get_servers_section(self, config: Dict[str, Any]) -> List[Dict[str, Any]]:
+        """Get the section of the config that contains server definitions
+
+        Args:
+            config: The loaded configuration
+
+        Returns:
+            The section containing server definitions
+        """
+        return config.get("mcpServers", [])
+
+    def _get_server_config(self, config: Dict[str, Any], server_name: str) -> Optional[Dict[str, Any]]:
+        """Get a server configuration from the config by name
+
+        Args:
+            config: The loaded configuration
+            server_name: Name of the server to find
+
+        Returns:
+            Server configuration if found, None otherwise
+        """
+        for server in self._get_servers_section(config):
+            if server.get("name") == server_name:
+                return server
+        return None
+
+    def _get_all_server_names(self, config: Dict[str, Any]) -> List[str]:
+        """Get all server names from the configuration
+
+        Args:
+            config: The loaded configuration
+
+        Returns:
+            List of server names
+        """
+        return [server.get("name") for server in self._get_servers_section(config) if server.get("name") is not None] # type: ignore
+
+    def _add_server_to_config(self, config: Dict[str, Any], server_name: str, server_config: Dict[str, Any]) -> Dict[str, Any]:
+        """Add or update a server in the config
+
+        Args:
+            config: The loaded configuration
+            server_name: Name of the server to add or update
+            server_config: Server configuration to add or update
+
+        Returns:
+            Updated configuration
+        """
+        # Ensure server_config has a name field for YAML list format
+        if "name" not in server_config:
+            server_config["name"] = server_name
+
+        # Find and update existing server or add new one
+        server_found = False
+        for i, server in enumerate(self._get_servers_section(config)):
+            if server.get("name") == server_name:
+                # Update existing server while preserving any extra fields
+                # that might be present in the original config
+                for key, value in server_config.items():
+                    config["mcpServers"][i][key] = value
+                server_found = True
+                break
+
+        if not server_found:
+            if "mcpServers" not in config:
+                config["mcpServers"] = []
+            config["mcpServers"].append(server_config)
+
+        return config
+
+    def _remove_server_from_config(self, config: Dict[str, Any], server_name: str) -> Dict[str, Any]:
+        """Remove a server from the config
+
+        Args:
+            config: The loaded configuration
+            server_name: Name of the server to remove
+
+        Returns:
+            Updated configuration
+        """
+        for i, server in enumerate(self._get_servers_section(config)):
+            if server.get("name") == server_name:
+                # Remove the server
+                config["mcpServers"].pop(i)
+                break
+        return config
+
+    def to_client_format(self, server_config: ServerConfig) -> Dict[str, Any]:
+        """Convert ServerConfig to Continue-specific format
+
+        Args:
+            server_config: ServerConfig object
+
+        Returns:
+            Dict containing client-specific configuration
+        """
+        # Base result containing essential information
+        result = {
+            "name": server_config.name,
+            "command": server_config.command,
+            "args": server_config.args,
+        }
+
+        # Add filtered environment variables if present
+        non_empty_env = server_config.get_filtered_env_vars(os.environ)
+        if non_empty_env:
+            result["env"] = non_empty_env
+
+        return result
+
+    def from_client_format(self, server_name: str, client_config: Dict[str, Any]) -> ServerConfig:
+        """Convert Continue format to ServerConfig
+
+        Args:
+            server_name: Name of the server
+            client_config: Client-specific configuration
+
+        Returns:
+            ServerConfig object
+        """
+        # Create a dictionary that ServerConfig.from_dict can work with
+        server_data = {
+            "name": server_name,
+            "command": client_config.get("command", ""),
+            "args": client_config.get("args", []),
+        }
+
+        # Add environment variables if present
+        if "env" in client_config:
+            server_data["env_vars"] = client_config["env"]
+
+        return ServerConfig.from_dict(server_data)

--- a/src/mcpm/clients/managers/fiveire.py
+++ b/src/mcpm/clients/managers/fiveire.py
@@ -1,0 +1,313 @@
+import json
+import logging
+import os
+import re
+from typing import Any, Dict, List, Optional, Union
+
+from mcpm.clients.base import JSONClientManager
+from mcpm.utils.server_config import ServerConfig
+
+logger = logging.getLogger(__name__)
+
+class FiveireManager(JSONClientManager):
+
+    # Client information
+    client_key = "5ire"
+    display_name = "5ire"
+    download_url = "https://5ire.app/"
+
+    configure_key_name = "servers"
+
+    def __init__(self, config_path=None):
+        """Initialize the 5ire client manager
+
+        Args:
+            config_path: Optional path to the config file. If not provided, uses default path.
+        """
+        super().__init__()
+
+        if config_path:
+            self.config_path = config_path
+        else:
+            # Set config path based on detected platform
+            if self._system == "Darwin":  # macOS
+                self.config_path = os.path.expanduser("~/Library/Application Support/5ire/mcp.json")
+            elif self._system == "Windows":
+                self.config_path = os.path.join(os.environ.get("APPDATA", ""), "5ire", "mcp.json")
+            else:
+                # Linux
+                self.config_path = os.path.expanduser("~/.config/5ire/mcp.json")
+
+    def _get_empty_config(self) -> Dict[str, Any]:
+        """Get an empty configuration structure for this client
+
+        Returns:
+            Dict containing the client configuration with at least {"servers": []}
+        """
+        return {self.configure_key_name: []}
+
+    def _load_config(self) -> Dict[str, Any]:
+        """Load client configuration file
+
+        Returns:
+            Dict containing the client configuration with at least {"servers": []}
+        """
+        # Create empty config with the correct structure
+        empty_config = self._get_empty_config()
+
+        if not os.path.exists(self.config_path):
+            logger.warning(f"Client config file not found at: {self.config_path}")
+            return empty_config
+
+        try:
+            with open(self.config_path, "r") as f:
+                config = json.load(f)
+                # Ensure servers section exists
+                if self.configure_key_name not in config:
+                    config[self.configure_key_name] = []
+                return config
+        except json.JSONDecodeError:
+            logger.error(f"Error parsing client config file: {self.config_path}")
+
+            # Backup the corrupt file
+            if os.path.exists(self.config_path):
+                backup_path = f"{self.config_path}.bak"
+                try:
+                    os.rename(self.config_path, backup_path)
+                    logger.info(f"Backed up corrupt config file to: {backup_path}")
+                except Exception as e:
+                    logger.error(f"Failed to backup corrupt file: {str(e)}")
+
+            # Return empty config
+            return empty_config
+
+    def get_servers(self) -> Dict[str, Any]:
+        """Get all MCP servers configured for this client
+
+        Returns:
+            Dict of server configurations by name
+        """
+        config = self._load_config()
+        servers = {}
+
+        # Convert list of servers to dictionary by name
+        for server in config.get(self.configure_key_name, []):
+            if "name" in server:
+                servers[server["name"]] = server
+
+        return servers
+
+    def get_server(self, server_name: str) -> Optional[ServerConfig]:
+        """Get a server configuration
+
+        Args:
+            server_name: Name of the server
+
+        Returns:
+            ServerConfig object if found, None otherwise
+        """
+        servers = self.get_servers()
+
+        # Check if the server exists
+        if server_name not in servers:
+            logger.debug(f"Server {server_name} not found in {self.display_name} config")
+            return None
+
+        # Get the server config and convert to ServerConfig
+        client_config = servers[server_name]
+        return self.from_client_format(server_name, client_config)
+
+    def add_server(self, server_config: Union[ServerConfig, Dict[str, Any]], name: Optional[str] = None) -> bool:
+        """Add or update a server in the client config
+
+        Args:
+            server_config: ServerConfig object or dictionary in client format
+            name: Required server name when using dictionary format
+
+        Returns:
+            bool: Success or failure
+        """
+        # Handle direct dictionary input
+        if isinstance(server_config, dict):
+            if name is None:
+                raise ValueError("Name must be provided when using dictionary format")
+            server_name = name
+            client_config = server_config  # Already in client format
+        # Handle ServerConfig objects
+        else:
+            server_name = server_config.name
+            client_config = self.to_client_format(server_config)
+            client_config["name"] = server_name  # Ensure name is in the config
+
+        # Update config
+        config = self._load_config()
+
+        # Check if server already exists and update it
+        server_exists = False
+        for i, server in enumerate(config.get(self.configure_key_name, [])):
+            if server.get("name") == server_name:
+                config[self.configure_key_name][i] = client_config
+                server_exists = True
+                break
+
+        # If server doesn't exist, add it
+        if not server_exists:
+            if self.configure_key_name not in config:
+                config[self.configure_key_name] = []
+            config[self.configure_key_name].append(client_config)
+
+        return self._save_config(config)
+
+    def to_client_format(self, server_config: ServerConfig) -> Dict[str, Any]:
+        """Convert ServerConfig to client-specific format
+
+        Args:
+            server_config: ServerConfig object
+
+        Returns:
+            Dict containing client-specific configuration
+        """
+        # Base result containing essential information
+        key_slug = re.sub(r"[^a-zA-Z0-9]", "", server_config.name)
+        # If the key starts with a number, prepend an key prefix
+        if key_slug and key_slug[0].isdigit():
+            key_slug = f"key{key_slug}"
+
+        result = {
+            "name": server_config.name,
+            "key": key_slug,
+            "command": server_config.command,
+            "args": server_config.args,
+            "isActive": True
+        }
+
+        # Add filtered environment variables if present
+        non_empty_env = server_config.get_filtered_env_vars(os.environ)
+        if non_empty_env:
+            result["env"] = non_empty_env
+
+        return result
+
+    @classmethod
+    def from_client_format(cls, server_name: str, client_config: Dict[str, Any]) -> ServerConfig:
+        """Convert client format to ServerConfig
+
+        Args:
+            server_name: Name of the server
+            client_config: Client-specific configuration
+
+        Returns:
+            ServerConfig object
+        """
+        # Create a dictionary that ServerConfig.from_dict can work with
+        server_data = {
+            "name": server_name,
+            "command": client_config.get("command", ""),
+            "args": client_config.get("args", []),
+        }
+
+        # Add environment variables if present
+        if "env" in client_config:
+            server_data["env_vars"] = client_config["env"]
+
+        return ServerConfig.from_dict(server_data)
+
+    def list_servers(self) -> List[str]:
+        """List all MCP servers in client config
+
+        Returns:
+            List of server names
+        """
+        return list(self.get_servers().keys())
+
+    def remove_server(self, server_name: str) -> bool:
+        """Remove an MCP server from client config
+
+        Args:
+            server_name: Name of the server to remove
+
+        Returns:
+            bool: Success or failure
+        """
+        config = self._load_config()
+
+        # Find and remove the server
+        server_found = False
+        for i, server in enumerate(config.get(self.configure_key_name, [])):
+            if server.get("name") == server_name:
+                config[self.configure_key_name].pop(i)
+                server_found = True
+                break
+
+        if not server_found:
+            logger.warning(f"Server {server_name} not found in {self.display_name} config")
+            return False
+
+        return self._save_config(config)
+
+    def disable_server(self, server_name: str) -> bool:
+        """Temporarily disable a server by setting isActive to False
+
+        Args:
+            server_name: Name of the server to disable
+
+        Returns:
+            bool: Success or failure
+        """
+        config = self._load_config()
+
+        # Find and disable the server
+        server_found = False
+        for i, server in enumerate(config.get(self.configure_key_name, [])):
+            if server.get("name") == server_name:
+                config[self.configure_key_name][i]["isActive"] = False
+                server_found = True
+                break
+
+        if not server_found:
+            logger.warning(f"Server {server_name} not found in {self.display_name} config")
+            return False
+
+        return self._save_config(config)
+
+    def enable_server(self, server_name: str) -> bool:
+        """Re-enable a previously disabled server by setting isActive to True
+
+        Args:
+            server_name: Name of the server to enable
+
+        Returns:
+            bool: Success or failure
+        """
+        config = self._load_config()
+
+        # Find and enable the server
+        server_found = False
+        for i, server in enumerate(config.get(self.configure_key_name, [])):
+            if server.get("name") == server_name:
+                config[self.configure_key_name][i]["isActive"] = True
+                server_found = True
+                break
+
+        if not server_found:
+            logger.warning(f"Server {server_name} not found in {self.display_name} config")
+            return False
+
+        return self._save_config(config)
+
+    def is_server_disabled(self, server_name: str) -> bool:
+        """Check if a server is currently disabled
+
+        Args:
+            server_name: Name of the server to check
+
+        Returns:
+            bool: True if server is disabled, False otherwise
+        """
+        servers = self.get_servers()
+
+        # Check if the server exists and is not active
+        return (
+            server_name in servers
+            and servers[server_name].get("isActive", True) is False
+        )

--- a/src/mcpm/clients/managers/goose.py
+++ b/src/mcpm/clients/managers/goose.py
@@ -1,0 +1,207 @@
+"""
+Goose MCP server configuration manager
+"""
+
+import logging
+import os
+from typing import Any, Dict, Optional
+
+from mcpm.clients.base import YAMLClientManager
+from mcpm.utils.server_config import ServerConfig
+
+logger = logging.getLogger(__name__)
+
+
+class GooseClientManager(YAMLClientManager):
+    """Manages Goose MCP server configurations
+
+    Goose uses YAML files for configuration with a specific structure for extensions.
+    This manager handles the Goose-specific configuration format and file locations.
+    """
+
+    # Client information
+    client_key = "goose"
+    display_name = "Goose"
+    download_url = "https://github.com/block/goose/releases/download/stable/download_cli.sh"
+
+    def __init__(self, config_path=None):
+        """Initialize the Goose client manager
+
+        Args:
+            config_path: Optional path to the config file. If not provided, uses default path.
+        """
+        super().__init__()
+        # Customize YAML handler
+        self.yaml_handler.indent(mapping=2, sequence=0, offset=0)
+        self.yaml_handler.preserve_quotes = True
+
+        if config_path:
+            self.config_path = config_path
+        else:
+            # Set config path based on detected platform
+            if os.name == "Darwin":  # macOS
+                self.config_path = os.path.expanduser("~/.config/goose/config.yaml")
+            elif os.name == "Windows":
+                self.config_path = os.path.join(os.environ.get("USERPROFILE", ""), ".config", "goose", "config.yaml")
+            else:
+                # Linux
+                self.config_path = os.path.expanduser("~/.config/goose/config.yaml")
+
+            # Also check for workspace config
+            workspace_config = os.path.join(os.getcwd(), ".goose", "config.yaml")
+            if os.path.exists(workspace_config):
+                # Prefer workspace config if it exists
+                self.config_path = workspace_config
+
+    def _get_empty_config(self) -> Dict[str, Any]:
+        """Get an empty configuration structure for Goose
+
+        Returns:
+            Dict containing the empty configuration structure
+        """
+        return {
+            "extensions": {}
+        }
+
+    def _get_servers_section(self, config: Dict[str, Any]) -> Dict[str, Any]:
+        """Get the section of the config that contains server definitions
+
+        Args:
+            config: The loaded configuration
+
+        Returns:
+            The section containing server definitions
+        """
+        return config.get("extensions", {})
+
+    def _get_server_config(self, config: Dict[str, Any], server_name: str) -> Optional[Dict[str, Any]]:
+        """Get a server configuration from the config by name
+
+        Args:
+            config: The loaded configuration
+            server_name: Name of the server to find
+
+        Returns:
+            Server configuration if found, None otherwise
+        """
+        return self._get_servers_section(config).get(server_name)
+
+    def _get_all_server_names(self, config: Dict[str, Any]) -> list[str]:
+        """Get all server names from the configuration
+
+        Args:
+            config: The loaded configuration
+
+        Returns:
+            List of server names
+        """
+        return list(self._get_servers_section(config).keys())
+
+    def _add_server_to_config(self, config: Dict[str, Any], server_name: str, server_config: Dict[str, Any]) -> Dict[str, Any]:
+        """Add or update a server in the config
+
+        Args:
+            config: The loaded configuration
+            server_name: Name of the server to add or update
+            server_config: Server configuration to add or update
+
+        Returns:
+            Updated configuration
+        """
+        if "extensions" not in config:
+            config["extensions"] = {}
+
+        config["extensions"][server_name] = server_config
+        return config
+
+    def _remove_server_from_config(self, config: Dict[str, Any], server_name: str) -> Dict[str, Any]:
+        """Remove a server from the config
+
+        Args:
+            config: The loaded configuration
+            server_name: Name of the server to remove
+
+        Returns:
+            Updated configuration
+        """
+        if "extensions" in config and server_name in config["extensions"]:
+            del config["extensions"][server_name]
+        return config
+
+    def _normalize_server_config(self, server_config: Dict[str, Any]) -> Dict[str, Any]:
+        """Normalize server configuration for external use
+
+        This method transforms Goose-specific configuration formats to a standard format
+        expected by external components.
+
+        Args:
+            server_config: Client-specific server configuration
+
+        Returns:
+            Normalized server configuration
+        """
+        # Create a copy
+        normalized = dict(server_config)
+
+        # Map Goose-specific fields to standard fields
+        if "cmd" in normalized:
+            normalized["command"] = normalized.pop("cmd")
+        if "envs" in normalized:
+            normalized["env"] = normalized.pop("envs")
+
+        return normalized
+
+    def to_client_format(self, server_config: ServerConfig) -> Dict[str, Any]:
+        """Convert ServerConfig to Goose-specific format
+
+        Args:
+            server_config: ServerConfig object
+
+        Returns:
+            Dict containing client-specific configuration
+        """
+        # Base result containing essential information
+        result = {
+            "cmd": server_config.command,
+            "args": server_config.args,
+            "name": server_config.display_name or server_config.name,
+            "enabled": True,
+            "description": server_config.description or None,
+            "type": "stdio"
+        }
+
+        # Add filtered environment variables if present
+        non_empty_env = server_config.get_filtered_env_vars(os.environ)
+        if non_empty_env:
+            result["envs"] = non_empty_env
+        else:
+            result["envs"] = {}
+
+        return result
+
+    def from_client_format(self, server_name: str, client_config: Dict[str, Any]) -> ServerConfig:
+        """Convert Goose format to ServerConfig
+
+        Args:
+            server_name: Name of the server
+            client_config: Client-specific configuration
+
+        Returns:
+            ServerConfig object
+        """
+        # Create a dictionary that ServerConfig.from_dict can work with
+        server_data = {
+            "name": server_name,
+            "command": client_config.get("cmd", ""),
+            "args": client_config.get("args", [])
+        }
+
+        # Add display name if present
+        if "name" in client_config:
+            server_data["display_name"] = client_config["name"]
+
+        # Add environment variables if present
+        if "envs" in client_config:
+            server_data["env_vars"] = client_config["envs"]
+
+        return ServerConfig.from_dict(server_data)

--- a/uv.lock
+++ b/uv.lock
@@ -258,6 +258,7 @@ dependencies = [
     { name = "pydantic" },
     { name = "requests" },
     { name = "rich" },
+    { name = "ruamel-yaml" },
 ]
 
 [package.metadata]
@@ -268,6 +269,7 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.5.1" },
     { name = "requests", specifier = ">=2.28.0" },
     { name = "rich", specifier = ">=12.0.0" },
+    { name = "ruamel-yaml", specifier = ">=0.18.10" },
 ]
 
 [[package]]
@@ -549,6 +551,62 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/20/dd/1f1a923d6cd798b8582176aca8a0784676f1a0449fb6f07fce6ac1cdbfb6/rpds_py-0.24.0-pp311-pypy311_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:eda5c1e2a715a4cbbca2d6d304988460942551e4e5e3b7457b50943cd741626d", size = 565818 },
     { url = "https://files.pythonhosted.org/packages/56/ec/d8da6df6a1eb3a418944a17b1cb38dd430b9e5a2e972eafd2b06f10c7c46/rpds_py-0.24.0-pp311-pypy311_pp73-musllinux_1_2_i686.whl", hash = "sha256:9abc80fe8c1f87218db116016de575a7998ab1629078c90840e8d11ab423ee25", size = 592627 },
     { url = "https://files.pythonhosted.org/packages/b3/14/c492b9c7d5dd133e13f211ddea6bb9870f99e4f73932f11aa00bc09a9be9/rpds_py-0.24.0-pp311-pypy311_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:6a727fd083009bc83eb83d6950f0c32b3c94c8b80a9b667c87f4bd1274ca30ba", size = 560885 },
+]
+
+[[package]]
+name = "ruamel-yaml"
+version = "0.18.10"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ruamel-yaml-clib", marker = "python_full_version < '3.13' and platform_python_implementation == 'CPython'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ea/46/f44d8be06b85bc7c4d8c95d658be2b68f27711f279bf9dd0612a5e4794f5/ruamel.yaml-0.18.10.tar.gz", hash = "sha256:20c86ab29ac2153f80a428e1254a8adf686d3383df04490514ca3b79a362db58", size = 143447 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/36/dfc1ebc0081e6d39924a2cc53654497f967a084a436bb64402dfce4254d9/ruamel.yaml-0.18.10-py3-none-any.whl", hash = "sha256:30f22513ab2301b3d2b577adc121c6471f28734d3d9728581245f1e76468b4f1", size = 117729 },
+]
+
+[[package]]
+name = "ruamel-yaml-clib"
+version = "0.2.12"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/20/84/80203abff8ea4993a87d823a5f632e4d92831ef75d404c9fc78d0176d2b5/ruamel.yaml.clib-0.2.12.tar.gz", hash = "sha256:6c8fbb13ec503f99a91901ab46e0b07ae7941cd527393187039aec586fdfd36f", size = 225315 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/70/57/40a958e863e299f0c74ef32a3bde9f2d1ea8d69669368c0c502a0997f57f/ruamel.yaml.clib-0.2.12-cp310-cp310-macosx_13_0_arm64.whl", hash = "sha256:11f891336688faf5156a36293a9c362bdc7c88f03a8a027c2c1d8e0bcde998e5", size = 131301 },
+    { url = "https://files.pythonhosted.org/packages/98/a8/29a3eb437b12b95f50a6bcc3d7d7214301c6c529d8fdc227247fa84162b5/ruamel.yaml.clib-0.2.12-cp310-cp310-manylinux2014_aarch64.whl", hash = "sha256:a606ef75a60ecf3d924613892cc603b154178ee25abb3055db5062da811fd969", size = 633728 },
+    { url = "https://files.pythonhosted.org/packages/35/6d/ae05a87a3ad540259c3ad88d71275cbd1c0f2d30ae04c65dcbfb6dcd4b9f/ruamel.yaml.clib-0.2.12-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fd5415dded15c3822597455bc02bcd66e81ef8b7a48cb71a33628fc9fdde39df", size = 722230 },
+    { url = "https://files.pythonhosted.org/packages/7f/b7/20c6f3c0b656fe609675d69bc135c03aac9e3865912444be6339207b6648/ruamel.yaml.clib-0.2.12-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f66efbc1caa63c088dead1c4170d148eabc9b80d95fb75b6c92ac0aad2437d76", size = 686712 },
+    { url = "https://files.pythonhosted.org/packages/cd/11/d12dbf683471f888d354dac59593873c2b45feb193c5e3e0f2ebf85e68b9/ruamel.yaml.clib-0.2.12-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:22353049ba4181685023b25b5b51a574bce33e7f51c759371a7422dcae5402a6", size = 663936 },
+    { url = "https://files.pythonhosted.org/packages/72/14/4c268f5077db5c83f743ee1daeb236269fa8577133a5cfa49f8b382baf13/ruamel.yaml.clib-0.2.12-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:932205970b9f9991b34f55136be327501903f7c66830e9760a8ffb15b07f05cd", size = 696580 },
+    { url = "https://files.pythonhosted.org/packages/30/fc/8cd12f189c6405a4c1cf37bd633aa740a9538c8e40497c231072d0fef5cf/ruamel.yaml.clib-0.2.12-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:a52d48f4e7bf9005e8f0a89209bf9a73f7190ddf0489eee5eb51377385f59f2a", size = 663393 },
+    { url = "https://files.pythonhosted.org/packages/80/29/c0a017b704aaf3cbf704989785cd9c5d5b8ccec2dae6ac0c53833c84e677/ruamel.yaml.clib-0.2.12-cp310-cp310-win32.whl", hash = "sha256:3eac5a91891ceb88138c113f9db04f3cebdae277f5d44eaa3651a4f573e6a5da", size = 100326 },
+    { url = "https://files.pythonhosted.org/packages/3a/65/fa39d74db4e2d0cd252355732d966a460a41cd01c6353b820a0952432839/ruamel.yaml.clib-0.2.12-cp310-cp310-win_amd64.whl", hash = "sha256:ab007f2f5a87bd08ab1499bdf96f3d5c6ad4dcfa364884cb4549aa0154b13a28", size = 118079 },
+    { url = "https://files.pythonhosted.org/packages/fb/8f/683c6ad562f558cbc4f7c029abcd9599148c51c54b5ef0f24f2638da9fbb/ruamel.yaml.clib-0.2.12-cp311-cp311-macosx_13_0_arm64.whl", hash = "sha256:4a6679521a58256a90b0d89e03992c15144c5f3858f40d7c18886023d7943db6", size = 132224 },
+    { url = "https://files.pythonhosted.org/packages/3c/d2/b79b7d695e2f21da020bd44c782490578f300dd44f0a4c57a92575758a76/ruamel.yaml.clib-0.2.12-cp311-cp311-manylinux2014_aarch64.whl", hash = "sha256:d84318609196d6bd6da0edfa25cedfbabd8dbde5140a0a23af29ad4b8f91fb1e", size = 641480 },
+    { url = "https://files.pythonhosted.org/packages/68/6e/264c50ce2a31473a9fdbf4fa66ca9b2b17c7455b31ef585462343818bd6c/ruamel.yaml.clib-0.2.12-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bb43a269eb827806502c7c8efb7ae7e9e9d0573257a46e8e952f4d4caba4f31e", size = 739068 },
+    { url = "https://files.pythonhosted.org/packages/86/29/88c2567bc893c84d88b4c48027367c3562ae69121d568e8a3f3a8d363f4d/ruamel.yaml.clib-0.2.12-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:811ea1594b8a0fb466172c384267a4e5e367298af6b228931f273b111f17ef52", size = 703012 },
+    { url = "https://files.pythonhosted.org/packages/11/46/879763c619b5470820f0cd6ca97d134771e502776bc2b844d2adb6e37753/ruamel.yaml.clib-0.2.12-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:cf12567a7b565cbf65d438dec6cfbe2917d3c1bdddfce84a9930b7d35ea59642", size = 704352 },
+    { url = "https://files.pythonhosted.org/packages/02/80/ece7e6034256a4186bbe50dee28cd032d816974941a6abf6a9d65e4228a7/ruamel.yaml.clib-0.2.12-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:7dd5adc8b930b12c8fc5b99e2d535a09889941aa0d0bd06f4749e9a9397c71d2", size = 737344 },
+    { url = "https://files.pythonhosted.org/packages/f0/ca/e4106ac7e80efbabdf4bf91d3d32fc424e41418458251712f5672eada9ce/ruamel.yaml.clib-0.2.12-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1492a6051dab8d912fc2adeef0e8c72216b24d57bd896ea607cb90bb0c4981d3", size = 714498 },
+    { url = "https://files.pythonhosted.org/packages/67/58/b1f60a1d591b771298ffa0428237afb092c7f29ae23bad93420b1eb10703/ruamel.yaml.clib-0.2.12-cp311-cp311-win32.whl", hash = "sha256:bd0a08f0bab19093c54e18a14a10b4322e1eacc5217056f3c063bd2f59853ce4", size = 100205 },
+    { url = "https://files.pythonhosted.org/packages/b4/4f/b52f634c9548a9291a70dfce26ca7ebce388235c93588a1068028ea23fcc/ruamel.yaml.clib-0.2.12-cp311-cp311-win_amd64.whl", hash = "sha256:a274fb2cb086c7a3dea4322ec27f4cb5cc4b6298adb583ab0e211a4682f241eb", size = 118185 },
+    { url = "https://files.pythonhosted.org/packages/48/41/e7a405afbdc26af961678474a55373e1b323605a4f5e2ddd4a80ea80f628/ruamel.yaml.clib-0.2.12-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:20b0f8dc160ba83b6dcc0e256846e1a02d044e13f7ea74a3d1d56ede4e48c632", size = 133433 },
+    { url = "https://files.pythonhosted.org/packages/ec/b0/b850385604334c2ce90e3ee1013bd911aedf058a934905863a6ea95e9eb4/ruamel.yaml.clib-0.2.12-cp312-cp312-manylinux2014_aarch64.whl", hash = "sha256:943f32bc9dedb3abff9879edc134901df92cfce2c3d5c9348f172f62eb2d771d", size = 647362 },
+    { url = "https://files.pythonhosted.org/packages/44/d0/3f68a86e006448fb6c005aee66565b9eb89014a70c491d70c08de597f8e4/ruamel.yaml.clib-0.2.12-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:95c3829bb364fdb8e0332c9931ecf57d9be3519241323c5274bd82f709cebc0c", size = 754118 },
+    { url = "https://files.pythonhosted.org/packages/52/a9/d39f3c5ada0a3bb2870d7db41901125dbe2434fa4f12ca8c5b83a42d7c53/ruamel.yaml.clib-0.2.12-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:749c16fcc4a2b09f28843cda5a193e0283e47454b63ec4b81eaa2242f50e4ccd", size = 706497 },
+    { url = "https://files.pythonhosted.org/packages/b0/fa/097e38135dadd9ac25aecf2a54be17ddf6e4c23e43d538492a90ab3d71c6/ruamel.yaml.clib-0.2.12-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:bf165fef1f223beae7333275156ab2022cffe255dcc51c27f066b4370da81e31", size = 698042 },
+    { url = "https://files.pythonhosted.org/packages/ec/d5/a659ca6f503b9379b930f13bc6b130c9f176469b73b9834296822a83a132/ruamel.yaml.clib-0.2.12-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:32621c177bbf782ca5a18ba4d7af0f1082a3f6e517ac2a18b3974d4edf349680", size = 745831 },
+    { url = "https://files.pythonhosted.org/packages/db/5d/36619b61ffa2429eeaefaab4f3374666adf36ad8ac6330d855848d7d36fd/ruamel.yaml.clib-0.2.12-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:b82a7c94a498853aa0b272fd5bc67f29008da798d4f93a2f9f289feb8426a58d", size = 715692 },
+    { url = "https://files.pythonhosted.org/packages/b1/82/85cb92f15a4231c89b95dfe08b09eb6adca929ef7df7e17ab59902b6f589/ruamel.yaml.clib-0.2.12-cp312-cp312-win32.whl", hash = "sha256:e8c4ebfcfd57177b572e2040777b8abc537cdef58a2120e830124946aa9b42c5", size = 98777 },
+    { url = "https://files.pythonhosted.org/packages/d7/8f/c3654f6f1ddb75daf3922c3d8fc6005b1ab56671ad56ffb874d908bfa668/ruamel.yaml.clib-0.2.12-cp312-cp312-win_amd64.whl", hash = "sha256:0467c5965282c62203273b838ae77c0d29d7638c8a4e3a1c8bdd3602c10904e4", size = 115523 },
+    { url = "https://files.pythonhosted.org/packages/29/00/4864119668d71a5fa45678f380b5923ff410701565821925c69780356ffa/ruamel.yaml.clib-0.2.12-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:4c8c5d82f50bb53986a5e02d1b3092b03622c02c2eb78e29bec33fd9593bae1a", size = 132011 },
+    { url = "https://files.pythonhosted.org/packages/7f/5e/212f473a93ae78c669ffa0cb051e3fee1139cb2d385d2ae1653d64281507/ruamel.yaml.clib-0.2.12-cp313-cp313-manylinux2014_aarch64.whl", hash = "sha256:e7e3736715fbf53e9be2a79eb4db68e4ed857017344d697e8b9749444ae57475", size = 642488 },
+    { url = "https://files.pythonhosted.org/packages/1f/8f/ecfbe2123ade605c49ef769788f79c38ddb1c8fa81e01f4dbf5cf1a44b16/ruamel.yaml.clib-0.2.12-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0b7e75b4965e1d4690e93021adfcecccbca7d61c7bddd8e22406ef2ff20d74ef", size = 745066 },
+    { url = "https://files.pythonhosted.org/packages/e2/a9/28f60726d29dfc01b8decdb385de4ced2ced9faeb37a847bd5cf26836815/ruamel.yaml.clib-0.2.12-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:96777d473c05ee3e5e3c3e999f5d23c6f4ec5b0c38c098b3a5229085f74236c6", size = 701785 },
+    { url = "https://files.pythonhosted.org/packages/84/7e/8e7ec45920daa7f76046578e4f677a3215fe8f18ee30a9cb7627a19d9b4c/ruamel.yaml.clib-0.2.12-cp313-cp313-musllinux_1_1_i686.whl", hash = "sha256:3bc2a80e6420ca8b7d3590791e2dfc709c88ab9152c00eeb511c9875ce5778bf", size = 693017 },
+    { url = "https://files.pythonhosted.org/packages/c5/b3/d650eaade4ca225f02a648321e1ab835b9d361c60d51150bac49063b83fa/ruamel.yaml.clib-0.2.12-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:e188d2699864c11c36cdfdada94d781fd5d6b0071cd9c427bceb08ad3d7c70e1", size = 741270 },
+    { url = "https://files.pythonhosted.org/packages/87/b8/01c29b924dcbbed75cc45b30c30d565d763b9c4d540545a0eeecffb8f09c/ruamel.yaml.clib-0.2.12-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:4f6f3eac23941b32afccc23081e1f50612bdbe4e982012ef4f5797986828cd01", size = 709059 },
+    { url = "https://files.pythonhosted.org/packages/30/8c/ed73f047a73638257aa9377ad356bea4d96125b305c34a28766f4445cc0f/ruamel.yaml.clib-0.2.12-cp313-cp313-win32.whl", hash = "sha256:6442cb36270b3afb1b4951f060eccca1ce49f3d087ca1ca4563a6eb479cb3de6", size = 98583 },
+    { url = "https://files.pythonhosted.org/packages/b0/85/e8e751d8791564dd333d5d9a4eab0a7a115f7e349595417fd50ecae3395c/ruamel.yaml.clib-0.2.12-cp313-cp313-win_amd64.whl", hash = "sha256:e5b8daf27af0b90da7bb903a876477a9e6d7270be6146906b276605997c7e9a3", size = 115190 },
 ]
 
 [[package]]


### PR DESCRIPTION
Introduce a couple of new mcp clients
+ [Cline(Extension in VSCode)](https://github.com/cline/cline)
+ [Continue(Extension in VSCode)](https://github.com/continuedev/continue)
+ [roo-code(Extension in VSCode and fork from Cline)](https://roocode.com/)
+ [goose(CLI only)](https://block.github.io/goose/docs/goose-architecture/#interoperability-with-extensions)
+ [5ire(Desktop)](https://github.com/nanbingxyz/5ire)

Continue is special cause it has a shared [ContinueDevHub](https://hub.continue.dev/explore/assistants) for custom assistants and the configure is stored remotely, so we only support for the mcp server management for local assistant currently.