### PR TITLE
Fix response being None

### DIFF
--- a/src/mcpm/router/transport.py
+++ b/src/mcpm/router/transport.py
@@ -240,6 +240,7 @@ class RouterSseTransport(SseServerTransport):
                 logger.warning(f"Connection error when sending message to session {session_id}: {e}")
                 self._read_stream_writers.pop(session_id, None)
                 self._session_id_to_identifier.pop(session_id, None)
+        return response
 
     def _validate_api_key(self, scope: Scope, api_key: str | None) -> bool:
         # If api_key is explicitly set to None, disable API key validation


### PR DESCRIPTION
This should resolve the TypeError: 'NoneType' object is not callable that was occurring because the handler was implicitly returning None. With this modification to the mcpm library source code (which OpenHands uses), the /messages endpoint should now function correctly without crashing.

See https://github.com/All-Hands-AI/OpenHands/issues/8859 for related issue