### PR TITLE
docs: Add documentation for mcpm share command

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,31 @@ mcpm router share                 # Share the router to public
 mcpm router unshare               # Unshare the router
 ```
 
+### 🤝 Share Management (`share`)
+
+The `mcpm share` command allows you to take any shell command that starts an MCP server and instantly expose it as an SSE (Server-Sent Events) server. It uses `mcp-proxy` to handle the server transformation and then creates a secure tunnel for remote access, making your local MCP server accessible from anywhere.
+
+This is particularly useful for quickly sharing a development server, a custom MCP server, or even a standard server with specific configurations without needing to deploy it publicly.
+
+```bash
+# 🚀 Share a local MCP server
+mcpm share "COMMAND" # Replace COMMAND with your actual server start command
+
+# ⚙️ Options
+# COMMAND: The shell command that starts your MCP server (e.g., "uvx mcp-server-fetch", "npx mcp-server"). This must be enclosed in quotes if it contains spaces.
+# --port PORT: Specify a local port for the mcp-proxy to listen on. Defaults to a random available port.
+# --address ADDRESS: Specify a public address for the tunnel (e.g., yourdomain.com:7000). If not provided, a random tunnel URL will be generated.
+# --http: If set, the tunnel will use HTTP instead of HTTPS. Use with caution.
+# --timeout TIMEOUT: Timeout in seconds for the mcp-proxy to wait for the server to start. Defaults to 60.
+# --retry RETRY: Number of times to retry starting the server if it fails. Defaults to 0.
+
+# 💡 Usage Examples
+mcpm share "uvx mcp-server-fetch"
+mcpm share "npx mcp-server" --port 5000
+mcpm share "uv run my-mcp-server" --address myserver.com:7000
+mcpm share "npx -y @modelcontextprotocol/server-everything" --retry 3
+```
+
 ### 🛠️ Utilities (`util`)
 
 ```bash

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -179,6 +179,31 @@ mcpm router share                 # 将router分享到公网
 mcpm router unshare               # 取消分享
 ```
 
+### 🤝 共享管理 (`share`)
+
+`mcpm share` 命令允许您将任何启动 MCP 服务器的 shell 命令，并立即将其公开为 SSE (Server-Sent Events) 服务器。它使用 `mcp-proxy` 处理服务器转换，然后创建一个安全隧道进行远程访问，使您的本地 MCP 服务器可以从任何地方访问。
+
+这对于快速共享开发服务器、自定义 MCP 服务器，甚至具有特定配置的标准服务器（无需公开部署）特别有用。
+
+```bash
+# 🚀 共享本地 MCP 服务器
+mcpm share "COMMAND" # 将 COMMAND 替换为您的实际服务器启动命令
+
+# ⚙️ 选项
+# COMMAND: 启动 MCP 服务器的 shell 命令 (例如 "uvx mcp-server-fetch", "npx mcp-server")。如果包含空格，则必须用引号括起来。
+# --port PORT: 指定 mcp-proxy 监听的本地端口。默认为随机可用端口。
+# --address ADDRESS: 指定隧道的公共地址 (例如 yourdomain.com:7000)。如果未提供，将生成随机隧道 URL。
+# --http: 如果设置，隧道将使用 HTTP 而不是 HTTPS。请谨慎使用。
+# --timeout TIMEOUT: mcp-proxy 等待服务器启动的超时时间（秒）。默认为 60。
+# --retry RETRY: 如果服务器启动失败，重试启动服务器的次数。默认为 0。
+
+# 💡 使用示例
+mcpm share "uvx mcp-server-fetch"
+mcpm share "npx mcp-server" --port 5000
+mcpm share "uv run my-mcp-server" --address myserver.com:7000
+mcpm share "npx -y @modelcontextprotocol/server-everything" --retry 3
+```
+
 ### 🛠️ 实用工具 (`util`)
 
 ```bash

--- a/pages/index.html
+++ b/pages/index.html
@@ -1001,6 +1001,27 @@
             </div>
         </div>
         
+        <h2><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-share-2"><circle cx="18" cy="5" r="3"></circle><circle cx="6" cy="12" r="3"></circle><circle cx="18" cy="19" r="3"></circle><line x1="8.59" y1="13.51" x2="15.42" y2="17.49"></line><line x1="15.41" y1="6.51" x2="8.59" y2="10.49"></line></svg> Share MCP Servers (<code>mcpm share</code>)</h2>
+        <p>Share a local MCP server with a public URL. MCPM uses mcp-proxy to expose a stdio MCP server as an SSE server and then creates a tunnel to make it accessible remotely.</p>
+        <div class="features">
+            <div class="feature">
+                <h3><span><svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-terminal"><polyline points="4 17 10 17 10 7"></polyline><line x1="20" y1="17" x2="4" y2="17"></line></svg></span> Share a Server</h3>
+                <p>Share a server using a specific command:</p>
+                <div class="code-block">
+                    <code><span class="command-prompt">$</span> mcpm share "uvx mcp-server-fetch"</code>
+                    <button class="copy-button" data-command='mcpm share "uvx mcp-server-fetch"'><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path></svg></button>
+                </div>
+            </div>
+            <div class="feature">
+                <h3><span><svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-zap"><polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"></polygon></svg></span> Share with Options</h3>
+                <p>Share a server and specify a port:</p>
+                <div class="code-block">
+                    <code><span class="command-prompt">$</span> mcpm share "npx mcp-server" --port 5000</code>
+                    <button class="copy-button" data-command='mcpm share "npx mcp-server" --port 5000'><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path></svg></button>
+                </div>
+            </div>
+        </div>
+
         <h2>Client Management</h2>
         <div class="features">
             <div class="feature">


### PR DESCRIPTION
This commit introduces documentation for the `mcpm share` command in the following places:

- README.md: Added a new section explaining the command, its options, and usage examples.
- README.zh-CN.md: Added a corresponding translated section.
- pages/index.html: Added a new section to the website describing the command and its usage, consistent with other documented commands.

The `mcpm share` command allows you to expose a local MCP server (given by a shell command) to a public URL by using `mcp-proxy` and creating a tunnel.