### PR TITLE
fix: automated fix for #171 via Codex

### DIFF
--- a/src/mcpm/clients/base.py
+++ b/src/mcpm/clients/base.py
@@ -418,7 +418,9 @@ class JSONClientManager(BaseClientManager):
         """
         host = router_config["host"]
         port = router_config["port"]
-        default_base_url = f"http://{host}:{port}/sse"
+
+        # Use streamable HTTP endpoint instead of the deprecated SSE one.
+        default_base_url = f"http://{host}:{port}/mcp/"
 
         server_config = self._format_router_server(profile_name, default_base_url, alias_name)
         return self.add_server(server_config)
@@ -688,7 +690,8 @@ class YAMLClientManager(BaseClientManager):
         """
         host = router_config["host"]
         port = router_config["port"]
-        default_base_url = f"http://{host}:{port}/sse"
+        # Use streamable HTTP endpoint.
+        default_base_url = f"http://{host}:{port}/mcp/"
 
         server_config = self._format_router_server(profile_name, default_base_url, alias_name)
         return self.add_server(server_config)

--- a/src/mcpm/utils/router_server.py
+++ b/src/mcpm/utils/router_server.py
@@ -4,7 +4,8 @@ from mcpm.core.schema import RemoteServerConfig, ServerConfig, STDIOServerConfig
 def format_server_url(client: str, profile: str, router_url: str, server_name: str | None = None) -> ServerConfig:
     return RemoteServerConfig(
         name=server_name if server_name else profile,
-        url=f"{router_url}?/client={client}&profile={profile}",
+        # Correct query parameters.
+        url=f"{router_url}?client={client}&profile={profile}",
     )
 
 
@@ -14,7 +15,7 @@ def format_server_url_with_proxy_param(
     result = STDIOServerConfig(
         name=server_name if server_name else profile,
         command="uvx",
-        args=["mcp-proxy", f"{router_url}?/client={client}&profile={profile}"],
+        args=["mcp-proxy", f"{router_url}?client={client}&profile={profile}"],
     )
     return result
 


### PR DESCRIPTION
Fixed router URL for client activation.

Key changes:
• src/mcpm/clients/base.py
– Switched default_base_url from “/sse” to “/mcp/” in both JSON & YAML client paths, ensuring clients use the streamable-HTTP endpoint when adding router servers.

• src/mcpm/utils/router_server.py
– Corrected generated query string: removed stray “/” so URLs are now
{base_url}?client=&profile=.
– Updated helper that builds proxy command to use the same corrected URL.

These updates ensure routers are added to clients with the new streamable HTTP endpoint instead of the deprecated SSE endpoint, aligning behaviour with current router implementation.