### PR TITLE
feat: change mcpm edit arguments from CSV to space-separated format

### DIFF
--- a/src/mcpm/commands/edit.py
+++ b/src/mcpm/commands/edit.py
@@ -3,6 +3,7 @@ Edit command for modifying server configurations
 """
 
 import os
+import shlex
 import subprocess
 import sys
 from typing import Any, Dict, Optional
@@ -190,9 +191,9 @@ def interactive_server_edit(server_config) -> Optional[Dict[str, Any]]:
                 # Arguments as space-separated string
                 current_args = " ".join(server_config.args) if server_config.args else ""
                 answers["args"] = inquirer.text(
-                    message="Arguments (space-separated):",
+                    message="Arguments (space-separated, quotes supported):",
                     default=current_args,
-                    instruction="(Leave empty for no arguments)",
+                    instruction="(Leave empty for no arguments, use quotes for args with spaces)",
                     keybindings={"interrupt": [{"key": "escape"}]},
                 ).execute()
 
@@ -237,7 +238,7 @@ def interactive_server_edit(server_config) -> Optional[Dict[str, Any]]:
 
             if isinstance(server_config, STDIOServerConfig):
                 console.print(f"Command: [cyan]{server_config.command}[/] → [cyan]{answers['command']}[/]")
-                new_args = answers["args"].split() if answers["args"] else []
+                new_args = shlex.split(answers["args"]) if answers["args"] else []
                 console.print(f"Arguments: [cyan]{server_config.args}[/] → [cyan]{new_args}[/]")
 
                 new_env = {}
@@ -298,7 +299,7 @@ def apply_interactive_changes(server_config, interactive_result):
 
         # Parse arguments
         if answers["args"].strip():
-            server_config.args = answers["args"].split()
+            server_config.args = shlex.split(answers["args"])
         else:
             server_config.args = []
 
@@ -381,7 +382,7 @@ def _create_new_server():
             server_config = STDIOServerConfig(
                 name=server_name,
                 command=result["answers"]["command"],
-                args=result["answers"]["args"].split() if result["answers"]["args"] else [],
+                args=shlex.split(result["answers"]["args"]) if result["answers"]["args"] else [],
                 env={},
             )
 
@@ -460,8 +461,8 @@ def _interactive_new_server_form() -> Optional[Dict[str, Any]]:
                 ).execute()
 
                 answers["args"] = inquirer.text(
-                    message="Arguments (space-separated):",
-                    instruction="(Leave empty for no arguments)",
+                    message="Arguments (space-separated, quotes supported):",
+                    instruction="(Leave empty for no arguments, use quotes for args with spaces)",
                     keybindings={"interrupt": [{"key": "escape"}]},
                 ).execute()
 
@@ -495,7 +496,7 @@ def _interactive_new_server_form() -> Optional[Dict[str, Any]]:
 
             if answers["type"] == "stdio":
                 console.print(f"Command: [cyan]{answers['command']}[/]")
-                new_args = answers["args"].split() if answers["args"] else []
+                new_args = shlex.split(answers["args"]) if answers["args"] else []
                 console.print(f"Arguments: [cyan]{new_args}[/]")
 
                 new_env = {}

--- a/tests/test_edit.py
+++ b/tests/test_edit.py
@@ -2,6 +2,7 @@
 Tests for the edit command
 """
 
+import shlex
 from unittest.mock import Mock
 
 from click.testing import CliRunner
@@ -51,6 +52,32 @@ def test_edit_server_interactive_fallback(monkeypatch):
     assert "This command requires a terminal for interactive input" in result.output
 
 
+def test_edit_server_with_spaces_in_args(monkeypatch):
+    """Test display of arguments with spaces in the fallback view."""
+    test_server = STDIOServerConfig(
+        name="test-server",
+        command="test-cmd",
+        args=["arg with spaces", "another arg", "--flag=value with spaces"],
+        env={"KEY": "value"},
+        profile_tags=["test-profile"],
+    )
+
+    mock_global_config = Mock()
+    mock_global_config.get_server.return_value = test_server
+    monkeypatch.setattr("mcpm.commands.edit.global_config_manager", mock_global_config)
+
+    runner = CliRunner()
+    result = runner.invoke(edit, ["test-server"])
+
+    # In test environment, interactive mode falls back and shows message
+    assert result.exit_code == 0
+    assert "Current Configuration for 'test-server'" in result.output
+    assert "test-cmd" in result.output
+    # Check that arguments with spaces are displayed correctly
+    assert "arg with spaces another arg --flag=value with spaces" in result.output
+    assert "Interactive editing not available" in result.output
+
+
 def test_edit_command_help():
     """Test the edit command help output."""
     runner = CliRunner()
@@ -94,3 +121,26 @@ def test_edit_editor_flag(monkeypatch):
 
     # Verify subprocess.run was called with correct arguments
     mock_subprocess.assert_called_once_with(["open", "/tmp/test_servers.json"])
+
+
+def test_shlex_argument_parsing():
+    """Test that shlex correctly parses arguments with spaces."""
+    # Test basic space-separated arguments
+    result = shlex.split("arg1 arg2 arg3")
+    assert result == ["arg1", "arg2", "arg3"]
+
+    # Test quoted arguments with spaces
+    result = shlex.split('arg1 "arg with spaces" arg3')
+    assert result == ["arg1", "arg with spaces", "arg3"]
+
+    # Test mixed quotes
+    result = shlex.split("arg1 'arg with spaces' --flag=\"value with spaces\"")
+    assert result == ["arg1", "arg with spaces", "--flag=value with spaces"]
+
+    # Test empty string
+    result = shlex.split("")
+    assert result == []
+
+    # Test single argument with spaces
+    result = shlex.split('"single arg with spaces"')
+    assert result == ["single arg with spaces"]


### PR DESCRIPTION
### **User description**
## Summary
- Changed argument parsing in `mcpm edit` command from comma-separated to space-separated format
- Updated all prompts and display formats to reflect this change
- Modified tests to match new behavior

## Context
This change improves the user experience by making argument input more natural. Users can now enter arguments separated by spaces instead of commas.

### Before
```
Arguments (comma-separated): arg1,arg2,arg3
```

### After
```
Arguments (space-separated): arg1 arg2 arg3
```

## Changes Made
- Updated argument parsing from `.split(",")` to `.split()` in all relevant locations
- Changed prompt messages from "comma-separated" to "space-separated"
- Updated table display format to show arguments with spaces
- Modified test expectations to match new format

## Test Plan
- [x] All existing tests pass
- [x] Manual testing of `mcpm edit` command works as expected
- [x] Code passes ruff linting and formatting checks

Fixes #212

🤖 Generated with [Claude Code](https://claude.ai/code)


___

### **PR Type**
Bug fix


___

### **Description**
- Changed argument parsing from comma-separated to space-separated format

- Updated prompts and display messages to reflect new format

- Modified tests to expect space-separated output


___

### **Changes diagram**

```mermaid
flowchart LR
  A["CSV Format"] -- "Replace .split(',')" --> B["Space Format"]
  B -- "Update prompts" --> C["User Interface"]
  B -- "Update display" --> D["Table Output"]
  B -- "Update tests" --> E["Test Expectations"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>edit.py</strong><dd><code>Convert CSV argument parsing to space-separated</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/mcpm/commands/edit.py

<li>Changed argument parsing from <code>.split(",")</code> to <code>.split()</code><br> <li> Updated prompts from "comma-separated" to "space-separated"<br> <li> Modified table display to show space-separated arguments<br> <li> Simplified argument parsing logic in multiple functions


</details>


  </td>
  <td><a href="https://github.com/pathintegral-institute/mcpm.sh/pull/213/files#diff-1df72da2251b6d3e3c940f3364475b3cd710ce1c864b8ea628233245e2fa2862">+9/-11</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_edit.py</strong><dd><code>Update test to expect space-separated output</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_edit.py

- Updated test expectation from "arg1, arg2" to "arg1 arg2"


</details>


  </td>
  <td><a href="https://github.com/pathintegral-institute/mcpm.sh/pull/213/files#diff-208934d2ac5a31b1450f3b468a278682e3d75828d3b5429cc7abd3904e07cc37">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>