### PR TITLE
Fix typo in ElevenLabs API key env variable name

### DIFF
--- a/mcp-registry/servers/elevenlabs-mcp.json
+++ b/mcp-registry/servers/elevenlabs-mcp.json
@@ -24,7 +24,7 @@
       "audio"
     ],
     "arguments": {
-      "ELEVEN_API_KEY": {
+      "ELEVENLABS_API_KEY": {
         "description": "Your ElevenLabs API key obtained from the ElevenLabs website.",
         "required": true,
         "example": "your-elevenlabs-api-key"
@@ -38,7 +38,7 @@
           "elevenlabs-mcp"
         ],
         "env": {
-          "ELEVEN_API_KEY": "${ELEVEN_API_KEY}"
+          "ELEVENLABS_API_KEY": "${ELEVENLABS_API_KEY}"
         }
       },
       "docker": {


### PR DESCRIPTION
### **User description**
Fixing a typo that I had in my previous PR 😢 :
https://github.com/pathintegral-institute/mcpm.sh/pull/194


___

### **PR Type**
Bug fix


___

### **Description**
- Fix typo in ElevenLabs API key environment variable name

- Update variable from `ELEVEN_API_KEY` to `ELEVENLABS_API_KEY`


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["ELEVEN_API_KEY"] -- "rename to" --> B["ELEVENLABS_API_KEY"]
  B --> C["arguments section"]
  B --> D["uvx installation env"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>elevenlabs-mcp.json</strong><dd><code>Fix ElevenLabs API key variable name typo</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

mcp-registry/servers/elevenlabs-mcp.json

<li>Rename <code>ELEVEN_API_KEY</code> to <code>ELEVENLABS_API_KEY</code> in arguments section<br> <li> Update environment variable reference in uvx installation <br>configuration


</details>


  </td>
  <td><a href="https://github.com/pathintegral-institute/mcpm.sh/pull/219/files#diff-1260c276f2000a1b8d9c5ae13ee925efe408224d7f58e9af4cebacd4153c8382">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

