### PR TITLE
fix: no banner when run profile in stdio mode

### DIFF
--- a/src/mcpm/commands/profile/run.py
+++ b/src/mcpm/commands/profile/run.py
@@ -117,7 +117,7 @@ async def run_profile_fastmcp(
         else:
             # Run the aggregated proxy over stdio (default)
             logger.info(f"Starting profile '{profile_name}' over stdio")
-            await proxy.run_stdio_async()
+            await proxy.run_stdio_async(show_banner=False)
 
         return 0
 


### PR DESCRIPTION
### **User description**
do not show fastmcp banner when running profile in stdio mode

Resolves #243 

___

### **PR Type**
Bug fix


___

### **Description**
- Disable banner display when running profile in stdio mode


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Profile Run"] --> B["Check Mode"]
  B --> C["HTTP/SSE Mode"]
  B --> D["Stdio Mode"]
  C --> E["Show Banner"]
  D --> F["Hide Banner"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>run.py</strong><dd><code>Disable banner for stdio mode execution</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/mcpm/commands/profile/run.py

<ul><li>Added <code>show_banner=False</code> parameter to <code>run_stdio_async()</code> call<br> <li> Prevents banner display when profile runs in stdio mode</ul>


</details>


  </td>
  <td><a href="https://github.com/pathintegral-institute/mcpm.sh/pull/251/files#diff-8183f363154a9ff08f908e4da4bb9859a0371bef8646fcae84b47255d8aa9ac1">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Startup banner is now suppressed in stdio mode, providing cleaner, less noisy output when running profiles.
  * HTTP/SSE modes are unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->