### PR TITLE
docs: update example usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,74 @@ The llm.txt file is automatically generated from the CLI structure and kept up-t
 
 ### ⚡ Example Usage
 
+#### Use case 1: expose a local stdio server over HTTP
+
+1) Add the server to MCPM
+```bash
+mcpm new [MY_SERVER_NAME] --type stdio --command "[COMMAND]" --args "[ARG_1] [ARG_2] ..."
+```
+(Add `--force` arg to bypass the confirmation interaction)
+Verify it appears in your installed servers:
+```bash
+mcpm ls
+```
+You should see `[MY_SERVER_NAME]` in the list.
+
+2) Serve it over HTTP
+```bash
+mcpm run [MY_SERVER_NAME] --http
+```
+MCPM prints the server URL, for example:
+```
+URL: http://127.0.0.1:6276/mcp/
+```
+
+3) Expose it on your network (optional)
+```bash
+mcpm run [MY_SERVER_NAME] --http --host 0.0.0.0
+```
+Tip: add `--port <PORT>` to choose a different port.
+
+
+#### Use case 2: combine multiple servers and serve them as one profile
+
+1) Add the servers to MCPM
+```bash
+# Stdio server
+mcpm new [SERVER_A] --type stdio --command "[COMMAND]" --args "[ARG_1] [ARG_2] ..." --force
+
+# Remote HTTP/SSE server
+mcpm new [SERVER_B] --type remote --url "http://SERVER_ADDR/mcp/" --force
+```
+
+2) Create a profile and add the servers
+Interactive:
+```bash
+mcpm profile create [PROFILE_NAME]
+mcpm profile edit [PROFILE_NAME]
+```
+MCPM would list out all installed servers, you can use arrows to navigate, space to select/deselect, type to search, and Enter to confirm.
+
+Verify:
+```bash
+mcpm profile ls
+```
+You should see your profile with the selected servers.
+
+3) Run the profile
+```bash
+# Stdio
+mcpm profile run [PROFILE_NAME]
+
+# HTTP
+mcpm profile run [PROFILE_NAME] --http
+
+# Optional: host and port
+mcpm profile run [PROFILE_NAME] --http --host 0.0.0.0 --port 8080
+```
+
+
+#### Other common usage
 ```bash
 # Server management
 mcpm new myserver --type stdio --command "python -m server" --force


### PR DESCRIPTION
### **PR Type**
Documentation


___

### **Description**
- Added comprehensive example usage section with two detailed use cases

- Included step-by-step instructions for HTTP server exposure

- Added profile management workflow examples

- Enhanced documentation with practical command examples


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Local stdio server"] --> B["Add to MCPM"]
  B --> C["Serve over HTTP"]
  C --> D["Optional network exposure"]
  E["Multiple servers"] --> F["Create profile"]
  F --> G["Run combined profile"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Comprehensive example usage documentation expansion</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<ul><li>Added two detailed use cases with step-by-step instructions<br> <li> Included HTTP server exposure and profile management workflows<br> <li> Enhanced existing example usage section with more comprehensive <br>examples<br> <li> Added minor formatting fix (newline at end of file)</ul>


</details>


  </td>
  <td><a href="https://github.com/pathintegral-institute/mcpm.sh/pull/254/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+69/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Added two step-by-step example sections: (1) exposing a local stdio server over HTTP with add/run/URL/optional port guidance; (2) combining multiple servers into a profile with interactive create/edit, listing, and running via stdio or HTTP with optional host/port.
  - Included these examples in both the main README’s example area and the LLM guide.

- Style
  - Minor formatting fix: added a trailing newline after the Star History image.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->