### PR TITLE
fix: route CLI error tracebacks to stderr instead of stdout

### DIFF
--- a/src/mcpm/cli.py
+++ b/src/mcpm/cli.py
@@ -7,6 +7,7 @@ from typing import Any, Dict
 
 from rich.console import Console
 from rich.traceback import Traceback
+from rich.traceback import install as install_rich_traceback
 
 from mcpm.clients.client_config import ClientConfigManager
 from mcpm.commands import (
@@ -37,6 +38,10 @@ client_config_manager = ClientConfigManager()
 
 # Setup Rich logging early - this runs when the module is imported
 setup_logging()
+
+# Install Rich's global exception handler to use stderr instead of stdout
+# This prevents Rich/rich-gradient from routing tracebacks to stdout
+install_rich_traceback(console=err_console, show_locals=True)
 
 # Custom context settings to handle main command help specially
 CONTEXT_SETTINGS: Dict[str, Any] = dict(help_option_names=[])


### PR DESCRIPTION
### **User description**
The console object in `cli.py` was created without `stderr=True`, causing unhandled exception tracebacks to be printed to `stdout` instead of `stderr`. This fix ensures proper error stream routing by configuring the console to use `stderr`, matching the behavior of the logging system.


___

### **PR Type**
Bug fix


___

### **Description**
- Configure CLI console to route error tracebacks to stderr

- Fix improper error stream routing in command-line interface


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["CLI Console Creation"] --> B["Add stderr=True parameter"] --> C["Error tracebacks route to stderr"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cli.py</strong><dd><code>Configure console for stderr error routing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/mcpm/cli.py

<ul><li>Modified Console initialization to include <code>stderr=True</code> parameter<br> <li> Ensures error tracebacks are properly routed to stderr stream</ul>


</details>


  </td>
  <td><a href="https://github.com/pathintegral-institute/mcpm.sh/pull/255/files#diff-b18da6768b002e1b119c978937265dfdbf26a54ed7d451da7c4e2ab77605bf4d">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - None.

- Bug Fixes
  - CLI diagnostics, rich tracebacks, and error banners now print to standard error instead of standard output, keeping regular command output clean. This improves piping, redirection, and automation reliability and ensures error output is separated from normal program output.

- Documentation
  - None.

- Refactor
  - None.

- Tests
  - None.

- Chores
  - None.

- Revert
  - None.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->