### PR TITLE
chore: deprecate unused workflow

### DIFF
--- a/.github/workflows/mcp-server-info-bot.yml
+++ b/.github/workflows/mcp-server-info-bot.yml
@@ -1,4 +1,4 @@
-name: [DEPRECATED] MCP Server Info Bot
+name: MCP Server Info Bot (DEPRECATED)
 
 permissions:
   contents: write
@@ -6,13 +6,17 @@ permissions:
   issues: write
 
 on:
-  issues:
-    types: [labeled]
+  workflow_dispatch:
+    inputs:
+      force_run:
+        description: 'Force run this deprecated workflow (not recommended)'
+        required: true
+        default: 'false'
 
 jobs:
   scrape-and-update:
     runs-on: ubuntu-latest
-    if: github.event.label.name == 'mcp-server-info-bot'  # Trigger only on 'mcp-server-info-bot' label
+    if: github.event.inputs.force_run == 'true' && false  # Disable this deprecated workflow
     steps:
       - name: Check if user is a maintainer
         uses: actions/github-script@v6


### PR DESCRIPTION
### **User description**
https://github.com/pathintegral-institute/mcpm.sh/actions/runs/17486979191/workflow


___

### **PR Type**
Other


___

### **Description**
- Deprecate MCP Server Info Bot workflow

- Change trigger from issue labels to manual dispatch

- Disable workflow execution with conditional logic

- Update workflow name to indicate deprecation


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Issue Label Trigger"] -- "replaced by" --> B["Manual Dispatch Trigger"]
  B -- "with condition" --> C["Force Run Input"]
  C -- "disabled by" --> D["False Condition"]
  D --> E["Workflow Disabled"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mcp-server-info-bot.yml</strong><dd><code>Deprecate and disable MCP Server Info Bot workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/mcp-server-info-bot.yml

<ul><li>Updated workflow name to indicate deprecation<br> <li> Changed trigger from issue labels to manual workflow dispatch<br> <li> Added force_run input parameter with default false<br> <li> Disabled workflow execution with conditional logic</ul>


</details>


  </td>
  <td><a href="https://github.com/pathintegral-institute/mcpm.sh/pull/258/files#diff-6e698da1d61c68653b3ab3c218b7b49905d4264179be969853660ffc65e878d6">+8/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Deprecated the MCP Server Info Bot workflow and updated its name to clearly indicate deprecation.
  - Replaced automatic issue-based triggering with a manual run option.
  - Added a force-run input to allow explicit manual execution when needed.
  - Ensured the workflow is effectively disabled by default to prevent unintended runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->