### PR TITLE
fix: set working directory if current is invalid

### DIFF
--- a/src/mcpm/cli.py
+++ b/src/mcpm/cli.py
@@ -31,6 +31,8 @@ from mcpm.commands.share import share
 from mcpm.migration import V1ConfigDetector, V1ToV2Migrator
 from mcpm.utils.logging_config import setup_logging
 from mcpm.utils.rich_click_config import click, get_header_text
+import os
+from pathlib import Path
 
 console = Console()          # stdout for regular CLI output
 err_console = Console(stderr=True)  # stderr for errors/tracebacks
@@ -86,6 +88,21 @@ with all MCP clients.
 @handle_exceptions
 def main(ctx, version, help_flag):
     """Main entry point for MCPM CLI."""
+
+    try:
+        # Check if the current working directory is valid.
+        os.getcwd()
+    except OSError:
+        # If getcwd() fails, it means the directory doesn't exist.
+        # This can happen when mcpm is called from certain environments
+        # like some Electron apps that don't set a valid cwd.
+        home_dir = str(Path.home())
+        err_console.print(
+            f"Current working directory is invalid. Changing to home directory: {home_dir}",
+            style="bold yellow"
+        )
+        os.chdir(home_dir)
+
     if version:
         print_logo()
         return


### PR DESCRIPTION
### **User description**
Resolves #228


___

### **PR Type**
Bug fix


___

### **Description**
- Fix invalid working directory issue in CLI

- Add error handling for OSError when getting current directory

- Automatically change to home directory when current directory is invalid

- Display warning message to user when directory change occurs


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["CLI Start"] --> B["Check Current Directory"]
  B --> C{"Directory Valid?"}
  C -->|Yes| D["Continue Normal Flow"]
  C -->|No| E["Change to Home Directory"]
  E --> F["Show Warning Message"]
  F --> D
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cli.py</strong><dd><code>Add working directory validation and fallback</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/mcpm/cli.py

<ul><li>Add imports for <code>os</code> and <code>Path</code> modules<br> <li> Add try-catch block to handle invalid working directory<br> <li> Change to home directory when current directory is invalid<br> <li> Display warning message to user when directory change occurs</ul>


</details>


  </td>
  <td><a href="https://github.com/pathintegral-institute/mcpm.sh/pull/261/files#diff-b18da6768b002e1b119c978937265dfdbf26a54ed7d451da7c4e2ab77605bf4d">+17/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

