### PR TITLE
ci: fix semantic release skipped due to head conflict

### DIFF
--- a/.github/workflows/generate-llm-txt.yml
+++ b/.github/workflows/generate-llm-txt.yml
@@ -1,20 +1,7 @@
 name: Generate LLM.txt
 
 on:
-  # Trigger on releases
-  release:
-    types: [published]
-  
-  # Trigger on pushes to main branch
-  push:
-    branches: [main]
-    paths:
-      - 'src/mcpm/commands/**'
-      - 'src/mcpm/cli.py'
-      - 'scripts/generate_llm_txt.py'
-  
-  # Allow manual trigger
-  workflow_dispatch:
+  workflow_call:
 
 jobs:
   generate-llm-txt:

--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -1,32 +1,37 @@
 name: Semantic Release
 
 on:
-  workflow_dispatch:
   push:
     branches:
       - main
     paths:
       - 'src/mcpm/**'
       - 'pyproject.toml'
+  workflow_dispatch:
 
 permissions:
   contents: write
   issues: write
   pull-requests: write
-  id-token: write  # Required for PyPI trusted publishing
+  id-token: write # Required for PyPI trusted publishing
 
 jobs:
+  update-llm-txt:
+    name: Update LLM.txt
+    uses: ./.github/workflows/generate-llm-txt.yml
+    secrets: inherit
+
   test:
     uses: ./.github/workflows/test.yml
 
   release:
     name: Release
-    needs: test
+    needs: [test, update-llm-txt]
     runs-on: ubuntu-latest
     environment:
       name: pypi
       url: https://pypi.org/p/mcpm
-    
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
### **User description**
- fix semantic release skipped as another workflow pushes to main


___

### **PR Type**
Other


___

### **Description**
- Convert LLM.txt generation from standalone to reusable workflow

- Add LLM.txt update as dependency in semantic release

- Remove manual triggers from LLM.txt workflow

- Ensure proper workflow sequencing for releases


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Semantic Release Workflow"] --> B["Update LLM.txt Job"]
  A --> C["Test Job"]
  B --> D["Release Job"]
  C --> D
  E["LLM.txt Workflow"] --> F["Reusable Workflow Call"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>generate-llm-txt.yml</strong><dd><code>Convert to reusable workflow call</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/generate-llm-txt.yml

<ul><li>Convert from standalone workflow to reusable workflow<br> <li> Remove all trigger events (push, release, workflow_dispatch)<br> <li> Replace with single <code>workflow_call</code> trigger</ul>


</details>


  </td>
  <td><a href="https://github.com/pathintegral-institute/mcpm.sh/pull/263/files#diff-627d910c6f5e0141aa853e5f5fb2f3f7ac6b035e1fa0452dbd96041d257e9494">+1/-14</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>semantic-release.yml</strong><dd><code>Add LLM.txt dependency to release workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/semantic-release.yml

<ul><li>Add <code>update-llm-txt</code> job that calls LLM.txt workflow<br> <li> Make release job depend on both test and update-llm-txt<br> <li> Reorder workflow_dispatch trigger position<br> <li> Add secrets inheritance for called workflow</ul>


</details>


  </td>
  <td><a href="https://github.com/pathintegral-institute/mcpm.sh/pull/263/files#diff-ea3710a52b3ef06a333289cb6d30d80091cde61d7f198ca449e463a6a52e4d39">+9/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Release workflow can now be triggered manually.
  * Release now depends on a pre-step that updates LLM.txt.
  * Converted a supporting workflow into a reusable one; it no longer runs automatically and is invoked by other workflows.
  * Enhanced checkout settings for full history and safer credential handling during releases.
  * No user-facing behavior changes outside the release process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->