### PR TITLE
Specify working pydantic version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "rich>=12.0.0",
     "rich-click>=1.8.0",
     "requests>=2.28.0",
-    "pydantic>=2.5.1",
+    "pydantic>=2.5.1,<2.12.0",
     "mcp>=1.8.0",
     "fastmcp==2.10.2",
     "ruamel-yaml>=0.18.10",


### PR DESCRIPTION
### **User description**
Pip and other package manager started resolving the pydantic dependency(used by FastMCP i believe) to versions >= 2.12.0 which seems to break with the error:
`TypeError: cannot specify both default and default_factory`
as described in #271 

Fixes #271


___

### **PR Type**
Bug fix


___

### **Description**
- Restrict pydantic version to <2.12.0 to avoid compatibility issues

- Resolves TypeError with default and default_factory conflict

- Pins working pydantic version range in dependencies


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["pydantic>=2.5.1"] -- "constrain upper bound" --> B["pydantic>=2.5.1,<2.12.0"]
  B -- "prevents TypeError" --> C["Resolves issue #271"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pyproject.toml</strong><dd><code>Constrain pydantic version upper bound</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pyproject.toml

<ul><li>Updated pydantic dependency constraint from <code>>=2.5.1</code> to <code>>=2.5.1,<2.12.0</code><br> <li> Prevents package managers from resolving to incompatible versions >= <br>2.12.0<br> <li> Fixes TypeError related to conflicting default and default_factory <br>parameters</ul>


</details>


  </td>
  <td><a href="https://github.com/pathintegral-institute/mcpm.sh/pull/272/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated pydantic dependency with an upper version bound to restrict supported versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->