### PR TITLE
feat: add Clarvia AEO Scanner to MCP registry

### DIFF
--- a/mcp-registry/servers/clarvia-aeo-scanner.json
+++ b/mcp-registry/servers/clarvia-aeo-scanner.json
@@ -1,0 +1,39 @@
+{
+    "display_name": "Clarvia AEO Scanner",
+    "license": "MIT",
+    "tags": [
+        "mcp",
+        "aeo",
+        "quality",
+        "scanner",
+        "discovery",
+        "agent",
+        "analysis",
+        "search"
+    ],
+    "installations": {
+        "clarvia-mcp-server": {
+            "type": "npm",
+            "command": "npx",
+            "args": [
+                "-y",
+                "clarvia-mcp-server@latest"
+            ],
+            "description": "Run the Clarvia AEO Scanner MCP server \u2014 search and analyze 27,000+ MCP tools"
+        }
+    },
+    "examples": [
+        {
+            "title": "Find the best database MCP server",
+            "prompt": "Search for the highest-rated database MCP servers and tell me which has the best AEO score"
+        },
+        {
+            "title": "Check my MCP server quality",
+            "prompt": "Analyze my MCP server at github.com/myorg/my-mcp-server and give me an AEO quality score"
+        },
+        {
+            "title": "Compare two MCP servers",
+            "prompt": "Compare supabase-mcp and postgres-mcp \u2014 which has better agent discoverability?"
+        }
+    ]
+}


### PR DESCRIPTION
## Add Clarvia AEO Scanner

**npm:** `clarvia-mcp-server` (v1.2.2) — https://www.npmjs.com/package/clarvia-mcp-server

**GitHub:** https://github.com/clarvia-project/scanner

### What is Clarvia?

Clarvia is an AEO (Agent Experience Optimization) quality scanner — the quality standard for MCP servers. It scores MCP tools for agent discoverability, structured data completeness, documentation quality, and trust signals.

**Install via MCPM:**
```bash
mcpm install clarvia-mcp-server
```

**Or directly:**
```bash
npx clarvia-mcp-server
```

### Tools provided (24 total)
- `search_tools` — Search 27,000+ indexed MCP servers by name, category, score
- `analyze_tool` — Get AEO quality score for any MCP server URL or npm package
- `compare_tools` — Head-to-head comparison with detailed score breakdown
- `get_trending_tools` — Discover what agents are installing this week
- `get_badge` — Get embeddable AEO score badge URL for README integration

### Why it belongs in this registry

Clarvia helps users and agents find the best MCP servers for their needs — it's a meta-tool that improves the entire MCP ecosystem's quality. No API key required. Free to use.

Adds `mcp-registry/servers/clarvia-aeo-scanner.json`.