### PR TITLE
Add server: elasticflow

### DIFF
--- a/mcp-registry/servers/elasticflow.json
+++ b/mcp-registry/servers/elasticflow.json
@@ -1,0 +1,56 @@
+{
+  "name": "elasticflow",
+  "display_name": "Elasticflow",
+  "description": "AI-native team workspace where agents and humans collaborate. Manage tables, documents, files, and publish live dashboards — all within your team's shared workspace.",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/elasticflowapp/elasticflow-mcp"
+  },
+  "homepage": "https://www.elasticflow.app",
+  "author": {
+    "name": "Elasticflow",
+    "url": "https://www.elasticflow.app"
+  },
+  "license": "MIT",
+  "categories": [
+    "Productivity",
+    "Professional Apps"
+  ],
+  "tags": [
+    "workspace",
+    "tables",
+    "documents",
+    "dashboards",
+    "agents",
+    "collaboration",
+    "oauth",
+    "http"
+  ],
+  "installations": {
+    "http": {
+      "type": "http",
+      "url": "https://mcp.elasticflow.app/mcp",
+      "description": "Streamable HTTP endpoint with OAuth 2.1 (PKCE). No API key required.",
+      "recommended": true
+    }
+  },
+  "examples": [
+    {
+      "title": "Build a sales pipeline table",
+      "description": "Create a structured table for tracking deals.",
+      "prompt": "Create a table called Pipeline with columns: company, deal size, stage, close date, owner"
+    },
+    {
+      "title": "Publish a client dashboard",
+      "description": "Build and publish a live dashboard without code.",
+      "prompt": "Build a client-facing dashboard showing project milestones for Acme Corp and publish it"
+    },
+    {
+      "title": "Search contracts",
+      "description": "Find information across all team documents.",
+      "prompt": "Search documents for all mentions of indemnification clause"
+    }
+  ],
+  "is_official": true,
+  "is_archived": false
+}


### PR DESCRIPTION
## Summary

Adds [Elasticflow](https://www.elasticflow.app) — an AI-native team workspace MCP server — to the registry.

- **Installation**: Streamable HTTP at `https://mcp.elasticflow.app/mcp`
- **Auth**: OAuth 2.1 with PKCE (no API key needed)
- **Tools**: 51 total across workspaces, tables, documents, files, and interfaces
- **Repository**: https://github.com/elasticflowapp/elasticflow-mcp
- **License**: MIT

## Validation

```
✓ elasticflow: Valid
```

via `python scripts/validate_manifest.py`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * elasticflow server is now available in the registry with OAuth 2.1 PKCE authentication and example prompts for table creation, dashboard publishing, and team document search.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->