### PR TITLE
feat(doctor): add --json output flag

### DIFF
--- a/src/mcpm/commands/doctor.py
+++ b/src/mcpm/commands/doctor.py
@@ -1,10 +1,12 @@
 """Doctor command for MCPM - System health check and diagnostics"""
 
+import json
 import os
 import shutil
 import subprocess
 import sys
 from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
 
 from rich.console import Console
 
@@ -18,176 +20,321 @@ console = Console()
 
 
 @click.command()
+@click.option("--json", "json_output", is_flag=True, help="Emit findings as JSON instead of human-readable Rich output.")
 @click.help_option("-h", "--help")
-def doctor():
+def doctor(json_output: bool) -> None:
     """Check system health and installed server status.
 
     Performs comprehensive diagnostics of MCPM installation, configuration,
     and installed servers.
 
     Examples:
-        mcpm doctor    # Run complete system health check
+        mcpm doctor             # Run complete system health check (Rich text output)
+        mcpm doctor --json      # Emit findings as JSON for programmatic consumption
     """
-    console.print("[bold green]🩺 MCPM System Health Check[/]")
-    console.print()
+    findings = _collect_findings()
+    if json_output:
+        _render_json(findings)
+    else:
+        _render_text(findings)
 
-    # Track overall health status
-    issues_found = 0
 
-    # 1. Check MCPM installation
-    console.print("[bold cyan]📦 MCPM Installation[/]")
+def _collect_findings() -> Dict[str, Any]:
+    """Run all diagnostic checks and return a structured findings dict.
+
+    The returned dict's shape is part of the public `--json` contract: each
+    top-level key (mcpm, python, node, config, cache, clients, profiles)
+    holds the corresponding section's structured data, and `summary` rolls
+    up the total `issues_found` count plus an `all_healthy` boolean. Adding
+    a new top-level key is non-breaking; renaming or removing an existing
+    one is a breaking change.
+    """
+    findings: Dict[str, Any] = {}
+    findings["mcpm"] = _check_mcpm()
+    findings["python"] = _check_python()
+    findings["node"] = _check_node()
+    findings["config"] = _check_config()
+    findings["cache"] = _check_cache()
+    findings["clients"] = _check_clients()
+    findings["profiles"] = _check_profiles()
+    issues_found = sum(int(section.get("issues", 0)) for section in findings.values())
+    findings["summary"] = {"issues_found": issues_found, "all_healthy": issues_found == 0}
+    return findings
+
+
+def _check_mcpm() -> Dict[str, Any]:
+    """Check MCPM installation. Returns version and any installation error."""
     try:
         from mcpm import __version__
 
-        console.print(f"  ✅ MCPM version: {__version__}")
+        return {"version": __version__, "error": None, "issues": 0}
     except Exception as e:
-        console.print(f"  ❌ MCPM installation error: {e}")
-        issues_found += 1
+        return {"version": None, "error": str(e), "issues": 1}
 
-    # 2. Check Python environment
-    console.print("[bold cyan]🐍 Python Environment[/]")
-    console.print(f"  ✅ Python version: {sys.version.split()[0]}")
-    console.print(f"  ✅ Python executable: {sys.executable}")
 
-    # Helper function to check CLI tools
-    def _check_cli_tool(tool_name: str, display_name: str, not_found_msg: str) -> int:
-        """Checks for a CLI tool, prints status, and returns 1 if an issue is found."""
-        tool_path = shutil.which(tool_name)
-        if tool_path:
-            try:
-                version = subprocess.check_output([tool_path, "--version"], stderr=subprocess.DEVNULL).decode().strip()
-                console.print(f"  ✅ {display_name} version: {version}")
-                return 0
-            except (subprocess.CalledProcessError, OSError):
-                console.print(f"  ⚠️  {display_name} found but failed to get version")
-                return 1
-        else:
-            console.print(f"  ⚠️  {not_found_msg}")
-            return 1
+def _check_python() -> Dict[str, Any]:
+    """Check Python environment. Always 0 issues — Python is always available."""
+    return {"version": sys.version.split()[0], "executable": sys.executable, "issues": 0}
 
-    # 3. Check Node.js (for npx servers)
-    # Use shutil.which() to find executables - handles Windows .cmd/.bat files via PATHEXT
-    console.print("[bold cyan]📊 Node.js Environment[/]")
-    issues_found += _check_cli_tool("node", "Node.js", "Node.js not found - npx servers will not work")
-    issues_found += _check_cli_tool("npm", "npm", "npm not found - package installation may fail")
 
-    # 4. Check MCPM configuration
-    console.print("[bold cyan]⚙️  MCPM Configuration[/]")
+def _check_cli_tool_status(tool_name: str) -> Tuple[Optional[str], Optional[str], int]:
+    """Return (version, error_message, issues_count) for a CLI tool on PATH.
+
+    Helper for `_check_node()` so both `node` and `npm` get the same
+    treatment without duplicating the subprocess + error-handling logic.
+    """
+    tool_path = shutil.which(tool_name)
+    if not tool_path:
+        return None, "not_found", 1
+    try:
+        version = subprocess.check_output([tool_path, "--version"], stderr=subprocess.DEVNULL).decode().strip()
+        return version, None, 0
+    except (subprocess.CalledProcessError, OSError):
+        return None, "version_check_failed", 1
+
+
+def _check_node() -> Dict[str, Any]:
+    """Check Node.js + npm availability for `npx` server execution."""
+    node_version, node_err, node_issues = _check_cli_tool_status("node")
+    npm_version, npm_err, npm_issues = _check_cli_tool_status("npm")
+    return {
+        "node": {"version": node_version, "error": node_err},
+        "npm": {"version": npm_version, "error": npm_err},
+        "issues": node_issues + npm_issues,
+    }
+
+
+def _check_config() -> Dict[str, Any]:
+    """Check MCPM configuration file."""
     try:
         config_manager = ConfigManager()
         config = config_manager.get_config()
-        console.print(f"  ✅ Config file: {config_manager.config_path}")
-
-        if config.get("node_executable"):
-            console.print(f"  ✅ Node executable: {config['node_executable']}")
-        else:
-            console.print("  ⚠️  No default node executable set")
-
+        node_executable = config.get("node_executable")
+        return {
+            "config_file": config_manager.config_path,
+            "node_executable": node_executable,
+            "node_executable_set": bool(node_executable),
+            "error": None,
+            "issues": 0,
+        }
     except Exception as e:
-        console.print(f"  ❌ Configuration error: {e}")
-        issues_found += 1
+        return {
+            "config_file": None,
+            "node_executable": None,
+            "node_executable_set": False,
+            "error": str(e),
+            "issues": 1,
+        }
 
-    # 5. Check repository cache
-    console.print("[bold cyan]📚 Repository Cache[/]")
+
+def _check_cache() -> Dict[str, Any]:
+    """Check repository cache file presence + age."""
     try:
+        import time
+
         repo_manager = RepositoryManager()
-        if os.path.exists(repo_manager.cache_file):
-            console.print(f"  ✅ Cache file: {repo_manager.cache_file}")
-
-            # Check cache age
-            cache_age = Path(repo_manager.cache_file).stat().st_mtime
-            import time
-
-            if time.time() - cache_age > 86400:  # 24 hours
-                console.print("  ⚠️  Cache is older than 24 hours - consider refreshing")
-        else:
-            console.print("  ⚠️  No cache file found - run 'mcpm search' to build cache")
-
+        cache_file = repo_manager.cache_file
+        cache_exists = os.path.exists(cache_file)
+        if not cache_exists:
+            return {"cache_file": cache_file, "exists": False, "stale": False, "error": None, "issues": 0}
+        cache_age = Path(cache_file).stat().st_mtime
+        stale = (time.time() - cache_age) > 86400
+        return {"cache_file": cache_file, "exists": True, "stale": stale, "error": None, "issues": 0}
     except Exception as e:
-        console.print(f"  ❌ Cache check error: {e}")
-        issues_found += 1
+        return {"cache_file": None, "exists": False, "stale": False, "error": str(e), "issues": 1}
 
-    # 6. Check supported clients
-    console.print("[bold cyan]🖥️  Supported Clients[/]")
+
+def _client_status_line(client: str) -> Optional[bool]:
+    """Return True if installed, False if not, None on detection error."""
+    try:
+        client_manager = ClientRegistry.get_client_manager(client)
+        if client_manager and client_manager.is_client_installed():
+            return True
+        return False
+    except Exception:
+        return None
+
+
+def _check_clients() -> Dict[str, Any]:
+    """Check supported MCP clients and which are installed locally."""
     try:
         clients = ClientRegistry.get_supported_clients()
-        console.print(f"  ✅ {len(clients)} clients supported:")
-
-        # Get display names for better readability
         client_info = ClientRegistry.get_all_client_info()
-
-        # Check which clients are installed
-        installed_clients = []
-        not_installed_clients = []
-
+        installed: List[str] = []
+        not_installed: List[str] = []
         for client in clients:
-            try:
-                client_manager = ClientRegistry.get_client_manager(client)
-                if client_manager and client_manager.is_client_installed():
-                    installed_clients.append(client)
-                else:
-                    not_installed_clients.append(client)
-            except Exception:
-                not_installed_clients.append(client)
-
-        # Show installed clients
-        if installed_clients:
-            console.print(f"    ✅ Installed ({len(installed_clients)}): ", end="")
-            display_names = []
-            for client in installed_clients:
-                info = client_info.get(client, {})
-                display_name = info.get("name", client)
-                display_names.append(display_name)
-            console.print(", ".join(display_names))
-
-        # Show available but not installed clients (first few)
-        if not_installed_clients:
-            console.print(f"    ⚪ Available ({len(not_installed_clients)}): ", end="")
-            display_names = []
-            for client in not_installed_clients[:3]:  # Show first 3
-                info = client_info.get(client, {})
-                display_name = info.get("name", client)
-                display_names.append(display_name)
-            if len(not_installed_clients) > 3:
-                display_names.append(f"and {len(not_installed_clients) - 3} more")
-            console.print(", ".join(display_names))
-
-        if not installed_clients and not not_installed_clients:
-            console.print("  ⚠️  No client information available")
-
+            status = _client_status_line(client)
+            if status:
+                installed.append(client)
+            else:
+                not_installed.append(client)
+        installed_display = [client_info.get(c, {}).get("name", c) for c in installed]
+        not_installed_display = [client_info.get(c, {}).get("name", c) for c in not_installed]
+        return {
+            "supported_count": len(clients),
+            "installed": installed,
+            "installed_display": installed_display,
+            "not_installed": not_installed,
+            "not_installed_display": not_installed_display,
+            "error": None,
+            "issues": 0,
+        }
     except Exception as e:
-        console.print(f"  ❌ Client check error: {e}")
-        issues_found += 1
+        return {
+            "supported_count": 0,
+            "installed": [],
+            "installed_display": [],
+            "not_installed": [],
+            "not_installed_display": [],
+            "error": str(e),
+            "issues": 1,
+        }
 
-    # 7. Check profiles
-    console.print("[bold cyan]📁 Profiles[/]")
+
+def _check_profiles() -> Dict[str, Any]:
+    """Check configured profiles."""
     try:
         profile_manager = ProfileConfigManager()
         profiles = profile_manager.list_profiles()
-        console.print(f"  ✅ {len(profiles)} profiles configured")
-
-        if profiles:
-            profile_names = list(profiles.keys()) if isinstance(profiles, dict) else profiles
-            for profile in profile_names[:3]:  # Show first 3
-                console.print(f"    - {profile}")
-            if len(profile_names) > 3:
-                console.print(f"    ... and {len(profile_names) - 3} more")
-
+        profile_names = list(profiles.keys()) if isinstance(profiles, dict) else list(profiles)
+        return {"count": len(profile_names), "names": profile_names, "error": None, "issues": 0}
     except Exception as e:
-        console.print(f"  ❌ Profile check error: {e}")
-        issues_found += 1
+        return {"count": 0, "names": [], "error": str(e), "issues": 1}
 
-    # 8. Summary
+
+def _json_default(obj: Any) -> str:
+    """Fallback for `json.dumps` — coerce PosixPath, Path, and other
+    non-serializable values to strings so the JSON output is robust against
+    upstream return shapes that mix `str` and `Path` for filesystem paths
+    (e.g. `RepositoryManager.cache_file`).
+    """
+    return str(obj)
+
+
+def _render_json(findings: Dict[str, Any]) -> None:
+    """Emit findings as JSON to stdout. Pretty-printed with indent=2."""
+    click.echo(json.dumps(findings, indent=2, default=_json_default))
+
+
+def _render_text(findings: Dict[str, Any]) -> None:
+    """Emit the existing Rich-formatted human-readable output.
+
+    Reproduces the pre-`--json` output verbatim by reading from the
+    structured findings dict instead of re-running the checks. Adding a
+    new finding to `_collect_findings` requires a corresponding render
+    block here — the JSON output drives the contract; text output is the
+    human-friendly view.
+    """
+    console.print("[bold green]🩺 MCPM System Health Check[/]")
     console.print()
-    if issues_found == 0:
+    _render_mcpm(findings["mcpm"])
+    _render_python(findings["python"])
+    _render_node(findings["node"])
+    _render_config(findings["config"])
+    _render_cache(findings["cache"])
+    _render_clients(findings["clients"])
+    _render_profiles(findings["profiles"])
+    _render_summary(findings["summary"])
+
+
+def _render_mcpm(section: Dict[str, Any]) -> None:
+    console.print("[bold cyan]📦 MCPM Installation[/]")
+    if section["error"]:
+        console.print(f"  ❌ MCPM installation error: {section['error']}")
+    else:
+        console.print(f"  ✅ MCPM version: {section['version']}")
+
+
+def _render_python(section: Dict[str, Any]) -> None:
+    console.print("[bold cyan]🐍 Python Environment[/]")
+    console.print(f"  ✅ Python version: {section['version']}")
+    console.print(f"  ✅ Python executable: {section['executable']}")
+
+
+def _render_node(section: Dict[str, Any]) -> None:
+    console.print("[bold cyan]📊 Node.js Environment[/]")
+    _render_cli_tool_line("Node.js", section["node"], "Node.js not found - npx servers will not work")
+    _render_cli_tool_line("npm", section["npm"], "npm not found - package installation may fail")
+
+
+def _render_cli_tool_line(display_name: str, info: Dict[str, Any], not_found_msg: str) -> None:
+    if info["version"]:
+        console.print(f"  ✅ {display_name} version: {info['version']}")
+    elif info["error"] == "version_check_failed":
+        console.print(f"  ⚠️  {display_name} found but failed to get version")
+    else:
+        console.print(f"  ⚠️  {not_found_msg}")
+
+
+def _render_config(section: Dict[str, Any]) -> None:
+    console.print("[bold cyan]⚙️  MCPM Configuration[/]")
+    if section["error"]:
+        console.print(f"  ❌ Configuration error: {section['error']}")
+        return
+    console.print(f"  ✅ Config file: {section['config_file']}")
+    if section["node_executable"]:
+        console.print(f"  ✅ Node executable: {section['node_executable']}")
+    else:
+        console.print("  ⚠️  No default node executable set")
+
+
+def _render_cache(section: Dict[str, Any]) -> None:
+    console.print("[bold cyan]📚 Repository Cache[/]")
+    if section["error"]:
+        console.print(f"  ❌ Cache check error: {section['error']}")
+        return
+    if not section["exists"]:
+        console.print("  ⚠️  No cache file found - run 'mcpm search' to build cache")
+        return
+    console.print(f"  ✅ Cache file: {section['cache_file']}")
+    if section["stale"]:
+        console.print("  ⚠️  Cache is older than 24 hours - consider refreshing")
+
+
+def _render_clients(section: Dict[str, Any]) -> None:
+    console.print("[bold cyan]🖥️  Supported Clients[/]")
+    if section["error"]:
+        console.print(f"  ❌ Client check error: {section['error']}")
+        return
+    console.print(f"  ✅ {section['supported_count']} clients supported:")
+    if section["installed_display"]:
+        console.print(f"    ✅ Installed ({len(section['installed_display'])}): ", end="")
+        console.print(", ".join(section["installed_display"]))
+    if section["not_installed_display"]:
+        not_installed = section["not_installed_display"]
+        console.print(f"    ⚪ Available ({len(not_installed)}): ", end="")
+        # Display first 3 + "and N more" suffix when truncating, matching
+        # the pre-`--json` Rich output verbatim.
+        display = list(not_installed[:3])
+        if len(not_installed) > 3:
+            display.append(f"and {len(not_installed) - 3} more")
+        console.print(", ".join(display))
+    if not section["installed_display"] and not section["not_installed_display"]:
+        console.print("  ⚠️  No client information available")
+
+
+def _render_profiles(section: Dict[str, Any]) -> None:
+    console.print("[bold cyan]📁 Profiles[/]")
+    if section["error"]:
+        console.print(f"  ❌ Profile check error: {section['error']}")
+        return
+    console.print(f"  ✅ {section['count']} profiles configured")
+    for profile in section["names"][:3]:
+        console.print(f"    - {profile}")
+    if section["count"] > 3:
+        console.print(f"    ... and {section['count'] - 3} more")
+
+
+def _render_summary(summary: Dict[str, Any]) -> None:
+    console.print()
+    if summary["all_healthy"]:
         console.print("[bold green]✅ All systems healthy! No issues found.[/]")
     else:
-        console.print(f"[bold yellow]⚠️  {issues_found} issue(s) detected.[/]")
+        console.print(f"[bold yellow]⚠️  {summary['issues_found']} issue(s) detected.[/]")
         console.print()
         console.print("[italic]Suggestions:[/]")
         console.print("  • Run 'mcpm config set' to configure node executable")
         console.print("  • Run 'mcpm search' to build repository cache")
         console.print("  • Install Node.js for npx server support")
-
     console.print()
     console.print("[italic]For more help, visit: https://github.com/pathintegral-institute/mcpm.sh[/]")

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -1,0 +1,165 @@
+"""Tests for the `mcpm doctor` command — both default Rich output and `--json`."""
+
+import json
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from mcpm.commands.doctor import (
+    _check_cli_tool_status,
+    _collect_findings,
+    doctor,
+)
+
+
+class TestCollectFindings:
+    """The structured findings dict is the public contract for `--json`.
+
+    These tests pin the keys / shape so adding a new check (non-breaking)
+    or removing one (breaking) is caught at test time. Implementation
+    details of individual checks are mocked in test_render_json to keep
+    these tests fast and deterministic.
+    """
+
+    def test_findings_has_all_section_keys(self):
+        findings = _collect_findings()
+        assert set(findings.keys()) == {
+            "mcpm",
+            "python",
+            "node",
+            "config",
+            "cache",
+            "clients",
+            "profiles",
+            "summary",
+        }
+
+    def test_summary_rolls_up_issues_found(self):
+        findings = _collect_findings()
+        # `summary.issues_found` equals the sum of every section's
+        # `issues` field (excluding the summary itself, which doesn't have
+        # an `issues` field). Pre-PR behavior matched this — mirrored here.
+        per_section_total = sum(
+            int(section.get("issues", 0)) for key, section in findings.items() if key != "summary"
+        )
+        assert findings["summary"]["issues_found"] == per_section_total
+
+    def test_summary_all_healthy_matches_zero_issues(self):
+        findings = _collect_findings()
+        assert findings["summary"]["all_healthy"] == (findings["summary"]["issues_found"] == 0)
+
+    def test_python_section_always_succeeds(self):
+        # Python is always available — the test is running in Python — so
+        # `python.issues` should always be 0. Pins the invariant the
+        # `_check_python()` helper documents.
+        findings = _collect_findings()
+        assert findings["python"]["issues"] == 0
+        assert isinstance(findings["python"]["version"], str)
+        assert isinstance(findings["python"]["executable"], str)
+
+
+class TestCheckCliToolStatus:
+    """Lower-level helper used by `_check_node()`. Pins the failure shapes
+    so the JSON contract for the `node` / `npm` sub-objects stays stable."""
+
+    def test_returns_not_found_when_tool_missing(self):
+        with patch("mcpm.commands.doctor.shutil.which", return_value=None):
+            version, error, issues = _check_cli_tool_status("nonexistent-binary-12345")
+        assert version is None
+        assert error == "not_found"
+        assert issues == 1
+
+    def test_returns_version_when_tool_succeeds(self):
+        with patch("mcpm.commands.doctor.shutil.which", return_value="/usr/bin/fake-tool"):
+            with patch(
+                "mcpm.commands.doctor.subprocess.check_output",
+                return_value=b"fake-tool 1.2.3\n",
+            ):
+                version, error, issues = _check_cli_tool_status("fake-tool")
+        assert version == "fake-tool 1.2.3"
+        assert error is None
+        assert issues == 0
+
+    def test_returns_version_check_failed_on_subprocess_error(self):
+        import subprocess
+
+        with patch("mcpm.commands.doctor.shutil.which", return_value="/usr/bin/fake-tool"):
+            with patch(
+                "mcpm.commands.doctor.subprocess.check_output",
+                side_effect=subprocess.CalledProcessError(1, "fake-tool"),
+            ):
+                version, error, issues = _check_cli_tool_status("fake-tool")
+        assert version is None
+        assert error == "version_check_failed"
+        assert issues == 1
+
+
+class TestDoctorJsonOutput:
+    """End-to-end tests of the `--json` flag emitting valid JSON to stdout."""
+
+    def test_json_output_is_valid_json(self):
+        runner = CliRunner()
+        result = runner.invoke(doctor, ["--json"])
+        assert result.exit_code == 0
+        parsed = json.loads(result.output)
+        # Sanity: top-level keys present.
+        assert "summary" in parsed
+        assert "issues_found" in parsed["summary"]
+        assert "all_healthy" in parsed["summary"]
+
+    def test_json_output_does_not_emit_rich_text(self):
+        # The Rich output uses `console.print` which goes to stderr in
+        # CliRunner. The `--json` path skips _render_text entirely, so
+        # stdout should contain ONLY the JSON payload — no banner emoji,
+        # no section headers.
+        runner = CliRunner()
+        result = runner.invoke(doctor, ["--json"])
+        assert result.exit_code == 0
+        # No Rich headers should leak into the JSON output.
+        assert "📦 MCPM Installation" not in result.output
+        assert "🩺 MCPM System Health Check" not in result.output
+        # Output should be parseable as JSON without trailing prose.
+        parsed = json.loads(result.output)
+        assert isinstance(parsed, dict)
+
+    def test_json_includes_all_check_section_keys(self):
+        runner = CliRunner()
+        result = runner.invoke(doctor, ["--json"])
+        parsed = json.loads(result.output)
+        # The full contract — every section the rendered text output
+        # surfaces is also surfaced in the JSON.
+        for key in ("mcpm", "python", "node", "config", "cache", "clients", "profiles", "summary"):
+            assert key in parsed, f"--json output missing top-level key {key}"
+
+    def test_json_summary_is_well_typed(self):
+        runner = CliRunner()
+        result = runner.invoke(doctor, ["--json"])
+        parsed = json.loads(result.output)
+        assert isinstance(parsed["summary"]["issues_found"], int)
+        assert isinstance(parsed["summary"]["all_healthy"], bool)
+
+
+class TestDoctorTextOutput:
+    """The default (no `--json`) path still emits the same Rich-formatted
+    output as before this change. This is the back-compat guarantee."""
+
+    def test_text_output_includes_known_banner(self):
+        runner = CliRunner()
+        result = runner.invoke(doctor)
+        assert result.exit_code == 0
+        # Banner emoji from the original implementation stays in place.
+        # Rich strips terminal colors when the output is captured by
+        # CliRunner so the test asserts on plain-text fragments only.
+        assert "MCPM System Health Check" in result.output
+
+    def test_text_output_does_not_emit_json(self):
+        runner = CliRunner()
+        result = runner.invoke(doctor)
+        # Without `--json`, the output is human-readable text; it should
+        # NOT be parseable as JSON (would imply the JSON path leaked).
+        try:
+            json.loads(result.output)
+            json_parsed = True
+        except json.JSONDecodeError:
+            json_parsed = False
+        assert not json_parsed


### PR DESCRIPTION
## Summary

Adds a `--json` flag to `mcpm doctor` so external tools can parse the health check status programmatically without scraping Rich-formatted text. The default Rich-text output for humans is unchanged.

## Why

Today `mcpm doctor` prints Rich-formatted text designed for terminal users. Programmatic consumers (CI dashboards, monitoring scripts, agent-config managers like agentbrew, IDE integrations) have no clean way to consume the diagnostic output — they'd need to scrape Rich-formatted text with regex, which is brittle.

`--json` emits a structured findings dict that downstream tools can reliably parse:

```json
{
  "mcpm": { "version": "2.14.0", "error": null, "issues": 0 },
  "python": { "version": "3.13.7", "executable": "/usr/local/bin/python3", "issues": 0 },
  "node": { "node": {...}, "npm": {...}, "issues": 0 },
  "config": { "config_file": "...", "node_executable": null, ... },
  "cache": { "cache_file": "...", "exists": true, "stale": false, ... },
  "clients": { "supported_count": 14, "installed": [...], "not_installed": [...], ... },
  "profiles": { "count": 0, "names": [], ... },
  "summary": { "issues_found": 1, "all_healthy": false }
}
```

## What changed

- `src/mcpm/commands/doctor.py`: refactored from inline-print into 8 `_check_*` helpers (each returns a structured dict) + 8 `_render_*` helpers + a `_render_json` path. Default text output is verbatim-unchanged; the JSON output drives the contract while text remains the human-friendly view.
- `tests/test_doctor.py`: 13 new tests covering `_collect_findings()` shape, `_check_cli_tool_status()` failure modes, `--json` output validity / shape / typing, and the default text output's invariants.

## Implementation notes

- `_json_default` coerces `PosixPath` to str for `cache_file` (RepositoryManager returns Path; the rest are str).
- The findings dict's top-level keys (`mcpm`, `python`, `node`, `config`, `cache`, `clients`, `profiles`, `summary`) are the public `--json` contract — adding new keys is non-breaking; renaming/removing is breaking.
- Each section's `issues` field rolls up into `summary.issues_found`.

## Test plan

- [x] `python3 -m pytest tests/test_doctor.py -v` — 13 tests pass
- [x] `python3 -m pytest tests/test_basic.py tests/test_cli.py -v` — existing tests still pass
- [x] `python3 -m ruff check src/mcpm/commands/doctor.py tests/test_doctor.py` — no warnings
- [x] Manual smoke: `python3 -m mcpm.cli doctor` (Rich output unchanged) and `python3 -m mcpm.cli doctor --json` (valid JSON emitted)

## Why this PR

Discussed in [agentbrew](https://github.intuit.com/expertnetwrk-portal/agentbrew)'s delegation roadmap as the smallest of 4 mcpm contribution slices that close out a `delegate-mcp-to-mcpm` parent task. Once merged, agentbrew's drift checker can call `mcpm doctor --json` for structured MCP-related health signals instead of falling back to text-scraping the Rich output. Standalone value for any tool that integrates with mcpm.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The `doctor` command now supports a `--json` flag for machine-readable diagnostic output in JSON format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->