### PR TITLE
feat(clients): add OpenCode client adapter

### DIFF
--- a/src/mcpm/clients/client_registry.py
+++ b/src/mcpm/clients/client_registry.py
@@ -19,6 +19,7 @@ from mcpm.clients.managers.cursor import CursorManager
 from mcpm.clients.managers.fiveire import FiveireManager
 from mcpm.clients.managers.gemini_cli import GeminiCliManager
 from mcpm.clients.managers.goose import GooseClientManager
+from mcpm.clients.managers.opencode import OpenCodeManager
 from mcpm.clients.managers.qwen_cli import QwenCliManager
 from mcpm.clients.managers.trae import TraeManager
 from mcpm.clients.managers.vscode import VSCodeManager
@@ -52,6 +53,7 @@ class ClientRegistry:
         "gemini-cli": GeminiCliManager,
         "codex-cli": CodexCliManager,
         "qwen-cli": QwenCliManager,
+        "opencode": OpenCodeManager,
     }
 
     @classmethod

--- a/src/mcpm/clients/managers/__init__.py
+++ b/src/mcpm/clients/managers/__init__.py
@@ -13,6 +13,7 @@ from mcpm.clients.managers.cursor import CursorManager
 from mcpm.clients.managers.fiveire import FiveireManager
 from mcpm.clients.managers.gemini_cli import GeminiCliManager
 from mcpm.clients.managers.goose import GooseClientManager
+from mcpm.clients.managers.opencode import OpenCodeManager
 from mcpm.clients.managers.qwen_cli import QwenCliManager
 from mcpm.clients.managers.trae import TraeManager
 from mcpm.clients.managers.vscode import VSCodeManager
@@ -32,4 +33,5 @@ __all__ = [
     "VSCodeManager",
     "GeminiCliManager",
     "CodexCliManager",
+    "OpenCodeManager",
 ]

--- a/src/mcpm/clients/managers/opencode.py
+++ b/src/mcpm/clients/managers/opencode.py
@@ -1,0 +1,68 @@
+"""
+OpenCode integration utilities for MCP
+"""
+
+import logging
+import os
+import shutil
+from typing import Any, Dict
+
+from mcpm.clients.base import JSONClientManager
+
+logger = logging.getLogger(__name__)
+
+
+class OpenCodeManager(JSONClientManager):
+    """Manages OpenCode MCP server configurations.
+
+    OpenCode is an open-source AI coding agent that runs as a CLI/TUI
+    (https://github.com/sst/opencode). Its config file is JSON at
+    `~/.config/opencode/opencode.json` and uses the top-level key `mcp`
+    (not the typical `mcpServers`).
+    """
+
+    # Client information
+    client_key = "opencode"
+    display_name = "OpenCode"
+    download_url = "https://github.com/sst/opencode"
+    configure_key_name = "mcp"  # OpenCode uses `mcp` instead of `mcpServers`
+
+    def __init__(self, config_path_override: str | None = None):
+        """Initialize the OpenCode client manager
+
+        Args:
+            config_path_override: Optional path to override the default config file location
+        """
+        super().__init__(config_path_override=config_path_override)
+
+        if config_path_override:
+            self.config_path = config_path_override
+        else:
+            # OpenCode stores its settings in ~/.config/opencode/opencode.json
+            self.config_path = os.path.expanduser("~/.config/opencode/opencode.json")
+
+    def _get_empty_config(self) -> Dict[str, Any]:
+        """Get empty config structure for OpenCode"""
+        return {self.configure_key_name: {}}
+
+    def is_client_installed(self) -> bool:
+        """Check if OpenCode is installed.
+
+        Returns:
+            bool: True if `opencode` binary is on PATH, False otherwise.
+        """
+        # shutil.which() handles Windows PATHEXT automatically (.cmd, .bat, .exe, etc.)
+        return shutil.which("opencode") is not None
+
+    def get_client_info(self) -> Dict[str, str]:
+        """Get information about this client
+
+        Returns:
+            Dict: Information about the client including display name, download URL, and config path
+        """
+        return {
+            "name": self.display_name,
+            "download_url": self.download_url,
+            "config_file": self.config_path,
+            "description": "Open-source AI coding agent (CLI / TUI)",
+        }

--- a/tests/test_clients/test_opencode.py
+++ b/tests/test_clients/test_opencode.py
@@ -1,0 +1,143 @@
+"""
+Test for OpenCode manager
+"""
+
+import json
+import os
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+from mcpm.clients.managers.opencode import OpenCodeManager
+
+
+def test_opencode_manager_initialization():
+    """Test OpenCodeManager initialization with default and override paths."""
+    manager = OpenCodeManager()
+    assert manager.client_key == "opencode"
+    assert manager.display_name == "OpenCode"
+    assert manager.download_url == "https://github.com/sst/opencode"
+    assert manager.config_path == str(Path.home() / ".config" / "opencode" / "opencode.json")
+
+    custom_path = "/tmp/custom_opencode.json"
+    manager = OpenCodeManager(config_path_override=custom_path)
+    assert manager.config_path == custom_path
+
+
+def test_opencode_manager_uses_mcp_key_not_mcpservers():
+    """Test that OpenCode uses the `mcp` key (not `mcpServers`).
+
+    This is the OpenCode-specific configuration shape — the JSON file
+    has a top-level `mcp` object instead of the `mcpServers` standard
+    used by Claude Code, Cursor, Cline, etc.
+    """
+    manager = OpenCodeManager()
+    assert manager.configure_key_name == "mcp"
+
+
+def test_opencode_manager_get_empty_config():
+    """Test OpenCodeManager _get_empty_config method returns the right shape."""
+    manager = OpenCodeManager()
+    config = manager._get_empty_config()
+    assert "mcp" in config
+    assert config["mcp"] == {}
+    # Sanity: no mcpServers key (the standard one).
+    assert "mcpServers" not in config
+
+
+def test_opencode_manager_is_client_installed_true():
+    """Test is_client_installed returns True when `opencode` binary is on PATH."""
+    manager = OpenCodeManager()
+    with patch("shutil.which", return_value="/usr/local/bin/opencode") as mock_which:
+        assert manager.is_client_installed() is True
+        mock_which.assert_called_with("opencode")
+
+
+def test_opencode_manager_is_client_installed_false():
+    """Test is_client_installed returns False when `opencode` is not on PATH."""
+    manager = OpenCodeManager()
+    with patch("shutil.which", return_value=None) as mock_which:
+        assert manager.is_client_installed() is False
+        mock_which.assert_called_with("opencode")
+
+
+def test_opencode_manager_is_client_installed_windows():
+    """Test that is_client_installed handles Windows PATHEXT via shutil.which."""
+    manager = OpenCodeManager()
+    # shutil.which() handles Windows PATHEXT automatically, so the manager
+    # always searches for "opencode" (no .exe / .cmd suffix). This keeps
+    # the manager OS-agnostic and matches the convention used by
+    # CodexCliManager, QwenCliManager, etc.
+    with patch("shutil.which", return_value="C:\\Users\\user\\AppData\\Roaming\\npm\\opencode.cmd") as mock_which:
+        assert manager.is_client_installed() is True
+        mock_which.assert_called_with("opencode")
+
+
+def test_opencode_manager_get_client_info():
+    """Test OpenCodeManager get_client_info method returns expected metadata."""
+    manager = OpenCodeManager()
+    info = manager.get_client_info()
+    assert info["name"] == "OpenCode"
+    assert info["download_url"] == "https://github.com/sst/opencode"
+    assert info["config_file"] == str(Path.home() / ".config" / "opencode" / "opencode.json")
+    assert "Open-source AI coding agent" in info["description"]
+
+
+def test_opencode_manager_loads_existing_mcp_section():
+    """Test that loading an existing config preserves the `mcp` section content."""
+    with tempfile.NamedTemporaryFile(delete=False, suffix=".json", mode="w") as f:
+        json.dump(
+            {
+                "mcp": {
+                    "memory": {
+                        "command": "npx",
+                        "args": ["-y", "@modelcontextprotocol/server-memory"],
+                    }
+                }
+            },
+            f,
+        )
+        temp_path = f.name
+
+    try:
+        manager = OpenCodeManager(config_path_override=temp_path)
+        config = manager._load_config()
+        assert "mcp" in config
+        assert "memory" in config["mcp"]
+        assert config["mcp"]["memory"]["command"] == "npx"
+    finally:
+        os.unlink(temp_path)
+
+
+def test_opencode_manager_creates_empty_mcp_section_for_missing_file():
+    """Test that loading a nonexistent file returns an empty `mcp` section."""
+    nonexistent_path = "/tmp/nonexistent-opencode-config-test.json"
+    manager = OpenCodeManager(config_path_override=nonexistent_path)
+    config = manager._load_config()
+    assert "mcp" in config
+    assert config["mcp"] == {}
+
+
+def test_opencode_manager_adds_server_under_mcp_key():
+    """Test that adding a server writes it under the `mcp` key (not `mcpServers`)."""
+    from mcpm.core.schema import STDIOServerConfig
+
+    with tempfile.NamedTemporaryFile(delete=False, suffix=".json", mode="w") as f:
+        json.dump({"mcp": {}}, f)
+        temp_path = f.name
+
+    try:
+        manager = OpenCodeManager(config_path_override=temp_path)
+        server_config = STDIOServerConfig(name="test-server", command="echo", args=["hello"])
+        success = manager.add_server(server_config)
+        assert success is True
+
+        # Verify the server was written under `mcp`, not `mcpServers`.
+        with open(temp_path) as f:
+            saved = json.load(f)
+        assert "mcp" in saved
+        assert "test-server" in saved["mcp"]
+        assert saved["mcp"]["test-server"]["command"] == "echo"
+        assert "mcpServers" not in saved
+    finally:
+        os.unlink(temp_path)


### PR DESCRIPTION
## Summary

Adds `OpenCodeManager` for [OpenCode](https://github.com/sst/opencode) — a popular open-source AI coding agent. Brings OpenCode into the supported client list alongside Claude Code, Cursor, Cline, etc.

## Why

OpenCode is widely used and ships an MCP-server config slot today (`~/.config/opencode/opencode.json`'s `mcp` key). Without first-class mcpm support, OpenCode users have to hand-edit JSON to install MCP servers — same friction every other client manager closes.

## Distinct config shape

OpenCode uses the top-level key `mcp` instead of the standard `mcpServers`. The new manager overrides `configure_key_name = "mcp"` so the `JSONClientManager` base class routes correctly:

```jsonc
{
  "mcp": {
    "memory": {
      "command": "npx",
      "args": ["-y", "@modelcontextprotocol/server-memory"]
    }
  }
}
```

## What changed

- **New** `src/mcpm/clients/managers/opencode.py` (70 LOC) — `OpenCodeManager` class extending `JSONClientManager`.
- **Updated** `src/mcpm/clients/managers/__init__.py` — re-export `OpenCodeManager`.
- **Updated** `src/mcpm/clients/client_registry.py` — register `"opencode": OpenCodeManager` in `_CLIENT_MANAGERS`.
- **New** `tests/test_clients/test_opencode.py` (143 LOC) — 10 tests covering:
  - Initialization with default + override paths.
  - `configure_key_name == "mcp"` distinction from the standard `mcpServers`.
  - `is_client_installed()` PATH-based detection (OS-agnostic via `shutil.which`).
  - `get_client_info()` metadata.
  - Load/add lifecycle: existing config preservation, empty-file handling, server-add writes under `mcp` key.

## Test plan

- [x] `python3 -m pytest tests/test_clients/test_opencode.py -v` — 10 tests pass
- [x] `python3 -m pytest tests/test_basic.py tests/test_cli.py tests/test_clients/ tests/test_doctor.py` — 65 tests pass (no regressions)
- [x] `python3 -m ruff check src/mcpm/clients/managers/opencode.py src/mcpm/clients/client_registry.py src/mcpm/clients/managers/__init__.py tests/test_clients/test_opencode.py` — no warnings
- [x] Manual smoke: `mcpm client ls` lists OpenCode under "Available" when not installed; `mcpm install <server>` properly writes under the `mcp` key when OpenCode is the active client.

## Why this PR

Discussed in [agentbrew](https://github.intuit.com/expertnetwrk-portal/agentbrew)'s delegation roadmap as one of 4 contribute-candidate adapters that close out a `delegate-mcp-to-mcpm` parent task. Once merged, agentbrew's OpenCode MCP carve-out becomes deletable — a small but real win for both projects.

Standalone value for any OpenCode user who wants `mcpm install` UX instead of hand-editing JSON.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Integrated OpenCode agent support enabling automatic installation detection and seamless MCP configuration management. The system now fully supports OpenCode as a client with dedicated configuration handling and complete metadata exposure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->