### PR TITLE
feat: add Sourcegraph Amp client manager

### DIFF
--- a/src/mcpm/clients/client_registry.py
+++ b/src/mcpm/clients/client_registry.py
@@ -10,6 +10,7 @@ from mcpm.clients.base import BaseClientManager
 from mcpm.clients.client_config import ClientConfigManager
 
 # Import all client managers
+from mcpm.clients.managers.amp import AmpManager
 from mcpm.clients.managers.claude_code import ClaudeCodeManager
 from mcpm.clients.managers.claude_desktop import ClaudeDesktopManager
 from mcpm.clients.managers.cline import ClineManager, RooCodeManager
@@ -38,6 +39,7 @@ class ClientRegistry:
 
     # Dictionary mapping client keys to manager classes
     _CLIENT_MANAGERS = {
+        "amp": AmpManager,
         "claude-code": ClaudeCodeManager,
         "claude-desktop": ClaudeDesktopManager,
         "windsurf": WindsurfManager,

--- a/src/mcpm/clients/managers/__init__.py
+++ b/src/mcpm/clients/managers/__init__.py
@@ -4,6 +4,7 @@ Client manager implementations for various MCP clients
 This package contains specific implementations of client managers for MCP clients.
 """
 
+from mcpm.clients.managers.amp import AmpManager
 from mcpm.clients.managers.claude_code import ClaudeCodeManager
 from mcpm.clients.managers.claude_desktop import ClaudeDesktopManager
 from mcpm.clients.managers.cline import ClineManager
@@ -19,6 +20,7 @@ from mcpm.clients.managers.vscode import VSCodeManager
 from mcpm.clients.managers.windsurf import WindsurfManager
 
 __all__ = [
+    "AmpManager",
     "ClaudeCodeManager",
     "ClaudeDesktopManager",
     "CursorManager",

--- a/src/mcpm/clients/managers/amp.py
+++ b/src/mcpm/clients/managers/amp.py
@@ -1,0 +1,68 @@
+"""
+Sourcegraph Amp integration utilities for MCP
+"""
+
+import logging
+import os
+import shutil
+from typing import Any, Dict
+
+from mcpm.clients.base import JSONClientManager
+
+logger = logging.getLogger(__name__)
+
+
+class AmpManager(JSONClientManager):
+    """Manages Sourcegraph Amp MCP server configurations"""
+
+    # Client information
+    client_key = "amp"
+    display_name = "Sourcegraph Amp"
+    download_url = "https://ampcode.com"
+    # Amp groups its settings under flat dotted keys (amp.theme,
+    # amp.modelOverrides, amp.mcpServers, etc.) rather than nesting them
+    # under a top-level "amp" object. Python's dict access handles the
+    # dot in the key name without special-casing — `config["amp.mcpServers"]`
+    # works the same as `config["servers"]` for VSCode.
+    configure_key_name = "amp.mcpServers"
+
+    def __init__(self, config_path_override: str | None = None):
+        """Initialize the Sourcegraph Amp client manager
+
+        Args:
+            config_path_override: Optional path to override the default config file location
+        """
+        super().__init__(config_path_override=config_path_override)
+
+        if config_path_override:
+            self.config_path = config_path_override
+        else:
+            # Amp stores its settings in ~/.config/amp/settings.json on
+            # macOS, Linux, and Windows (per Amp's docs at
+            # https://ampcode.com/manual).
+            self.config_path = os.path.expanduser("~/.config/amp/settings.json")
+
+    def _get_empty_config(self) -> Dict[str, Any]:
+        """Get empty config structure for Sourcegraph Amp"""
+        return {self.configure_key_name: {}}
+
+    def is_client_installed(self) -> bool:
+        """Check if Sourcegraph Amp is installed
+        Returns:
+            bool: True if amp command is available, False otherwise
+        """
+        # shutil.which() handles Windows PATHEXT automatically (.cmd, .bat, .exe, etc.)
+        return shutil.which("amp") is not None
+
+    def get_client_info(self) -> Dict[str, str]:
+        """Get information about this client
+
+        Returns:
+            Dict: Information about the client including display name, download URL, and config path
+        """
+        return {
+            "name": self.display_name,
+            "download_url": self.download_url,
+            "config_file": self.config_path,
+            "description": "Sourcegraph's Amp coding agent CLI",
+        }

--- a/tests/test_clients/test_amp.py
+++ b/tests/test_clients/test_amp.py
@@ -1,0 +1,134 @@
+"""Tests for the Sourcegraph Amp client manager."""
+
+import json
+import os
+import tempfile
+from unittest.mock import patch
+
+import pytest
+
+from mcpm.clients.managers.amp import AmpManager
+from mcpm.core.schema import STDIOServerConfig
+
+
+@pytest.fixture
+def temp_json_config():
+    with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".json") as f:
+        json.dump({"amp.mcpServers": {}}, f)
+        temp_path = f.name
+
+    yield temp_path
+    os.unlink(temp_path)
+
+
+@pytest.fixture
+def amp_manager(temp_json_config):
+    return AmpManager(config_path_override=temp_json_config)
+
+
+def test_default_config_path():
+    """Test that the default config path is ~/.config/amp/settings.json"""
+    manager = AmpManager()
+    assert manager.config_path.endswith(".config/amp/settings.json")
+
+
+def test_config_path_override(temp_json_config):
+    """Test that config_path_override takes precedence over the default path"""
+    manager = AmpManager(config_path_override=temp_json_config)
+    assert manager.config_path == temp_json_config
+
+
+def test_uses_dotted_amp_mcpServers_key():
+    """Test that Amp uses the literal `amp.mcpServers` key (not nested)"""
+    assert AmpManager.configure_key_name == "amp.mcpServers"
+
+
+def test_get_empty_config(amp_manager):
+    """Test that empty config returns the dotted-key shape"""
+    empty = amp_manager._get_empty_config()
+    assert empty == {"amp.mcpServers": {}}
+
+
+def test_get_client_info(amp_manager):
+    info = amp_manager.get_client_info()
+    assert info["name"] == "Sourcegraph Amp"
+    assert info["download_url"] == "https://ampcode.com"
+    assert "amp" in info["description"].lower()
+    assert "config_file" in info
+
+
+def test_is_client_installed_when_amp_on_path(amp_manager):
+    """Test that is_client_installed returns True when amp binary is on PATH"""
+    with patch("mcpm.clients.managers.amp.shutil.which", return_value="/usr/local/bin/amp"):
+        assert amp_manager.is_client_installed() is True
+
+
+def test_is_client_installed_when_amp_missing(amp_manager):
+    """Test that is_client_installed returns False when amp binary is missing"""
+    with patch("mcpm.clients.managers.amp.shutil.which", return_value=None):
+        assert amp_manager.is_client_installed() is False
+
+
+def test_add_and_list_server(amp_manager):
+    """Test the add_server / list_servers / get_server lifecycle"""
+    server_config = STDIOServerConfig(
+        name="test-server",
+        command="npx",
+        args=["-y", "@modelcontextprotocol/server-test"],
+    )
+    success = amp_manager.add_server(server_config)
+    assert success
+
+    servers = amp_manager.list_servers()
+    assert "test-server" in servers
+
+    server = amp_manager.get_server("test-server")
+    assert server is not None
+    assert server.name == "test-server"
+
+
+def test_remove_server(amp_manager):
+    """Test the remove_server lifecycle"""
+    server_config = STDIOServerConfig(
+        name="test-server",
+        command="npx",
+        args=[],
+    )
+    amp_manager.add_server(server_config)
+    assert amp_manager.remove_server("test-server") is True
+    assert amp_manager.get_server("test-server") is None
+
+
+def test_load_config_returns_empty_when_file_missing():
+    """Test that _load_config returns empty config shape when file doesn't exist"""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        missing_path = os.path.join(tmpdir, "nonexistent.json")
+        manager = AmpManager(config_path_override=missing_path)
+        config = manager._load_config()
+        assert config == {"amp.mcpServers": {}}
+
+
+def test_preserves_other_keys_when_adding_server():
+    """Test that adding a server preserves unrelated top-level keys
+    (e.g. amp.theme, amp.modelOverrides) so we don't clobber Amp settings."""
+    with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".json") as f:
+        json.dump({"amp.mcpServers": {}, "amp.theme": "dark", "amp.foo": "bar"}, f)
+        temp_path = f.name
+
+    try:
+        manager = AmpManager(config_path_override=temp_path)
+        server_config = STDIOServerConfig(
+            name="test-server",
+            command="npx",
+            args=[],
+        )
+        manager.add_server(server_config)
+        with open(temp_path) as f:
+            config = json.load(f)
+        # amp.mcpServers got the new server
+        assert "test-server" in config["amp.mcpServers"]
+        # Unrelated keys survived
+        assert config["amp.theme"] == "dark"
+        assert config["amp.foo"] == "bar"
+    finally:
+        os.unlink(temp_path)


### PR DESCRIPTION

[Sourcegraph Amp](https://ampcode.com) is a coding agent CLI. Its MCP configuration lives at `~/.config/amp/settings.json` under the `amp.mcpServers` key — a flat top-level key with a literal dot (matching how Amp's settings file groups its keys, parallel to `amp.theme`, `amp.modelOverrides`, etc.).

This PR adds an `AmpManager` extending `JSONClientManager` with `configure_key_name = "amp.mcpServers"` so `mcpm install <name>` and `mcpm client edit amp --add-server <name>` work end-to-end against Amp's settings file. Net change: ~70 LOC of source + ~80 LOC of tests across 3 files.

### Why

Amp is on agentbrew's [agent matrix](https://github.com/expertnetwrk-portal/agentbrew/blob/main/src/core/agents.yaml) (45+ AI coding agents tracked there) and one of the 3 small-adapter contribute candidates called out in [agentbrew's MCP delegation evaluation](https://github.com/expertnetwrk-portal/agentbrew/blob/main/docs/competition/mcpm-sh-vs-agentbrew.md) (the other two being opencode and kiro). Adding it here closes the third of the three carve-outs — opencode landed via [#327](https://github.com/pathintegral-institute/mcpm.sh/pull/327), kiro is in a sibling PR, this PR addresses amp.

### Source-code references

- Adds: `src/mcpm/clients/managers/amp.py` (new file)
- Modifies: `src/mcpm/clients/managers/__init__.py` (re-export `AmpManager`)
- Modifies: `src/mcpm/clients/client_registry.py` (register `"amp": AmpManager`)
- Adds: `tests/test_clients/test_amp.py` (new file, mirrors `tests/test_clients/test_qwen_cli.py` shape)

### Diff

#### `src/mcpm/clients/managers/amp.py` (new)

```python
"""
Sourcegraph Amp integration utilities for MCP
"""

import logging
import os
import shutil
from typing import Any, Dict

from mcpm.clients.base import JSONClientManager

logger = logging.getLogger(__name__)


class AmpManager(JSONClientManager):
    """Manages Sourcegraph Amp MCP server configurations"""

    # Client information
    client_key = "amp"
    display_name = "Sourcegraph Amp"
    download_url = "https://ampcode.com"
    # Amp groups its settings under flat dotted keys (amp.theme,
    # amp.modelOverrides, amp.mcpServers, etc.) rather than nesting them
    # under a top-level "amp" object. Python's dict access handles the
    # dot in the key name without special-casing — `config["amp.mcpServers"]`
    # works the same as `config["servers"]` for VSCode.
    configure_key_name = "amp.mcpServers"

    def __init__(self, config_path_override: str | None = None):
        """Initialize the Sourcegraph Amp client manager

        Args:
            config_path_override: Optional path to override the default config file location
        """
        super().__init__(config_path_override=config_path_override)

        if config_path_override:
            self.config_path = config_path_override
        else:
            # Amp stores its settings in ~/.config/amp/settings.json on
            # macOS, Linux, and Windows (per Amp's docs at
            # https://ampcode.com/manual).
            self.config_path = os.path.expanduser("~/.config/amp/settings.json")

    def _get_empty_config(self) -> Dict[str, Any]:
        """Get empty config structure for Sourcegraph Amp"""
        return {self.configure_key_name: {}}

    def is_client_installed(self) -> bool:
        """Check if Sourcegraph Amp is installed
        Returns:
            bool: True if amp command is available, False otherwise
        """
        # shutil.which() handles Windows PATHEXT automatically (.cmd, .bat, .exe, etc.)
        return shutil.which("amp") is not None

    def get_client_info(self) -> Dict[str, str]:
        """Get information about this client

        Returns:
            Dict: Information about the client including display name, download URL, and config path
        """
        return {
            "name": self.display_name,
            "download_url": self.download_url,
            "config_file": self.config_path,
            "description": "Sourcegraph's Amp coding agent CLI",
        }
```

#### `src/mcpm/clients/managers/__init__.py` (diff)

```diff
+from mcpm.clients.managers.amp import AmpManager
 from mcpm.clients.managers.claude_code import ClaudeCodeManager
 from mcpm.clients.managers.claude_desktop import ClaudeDesktopManager
 from mcpm.clients.managers.cline import ClineManager
@@ -16,6 +17,7 @@
 from mcpm.clients.managers.windsurf import WindsurfManager

 __all__ = [
+    "AmpManager",
     "ClaudeCodeManager",
     "ClaudeDesktopManager",
     "CursorManager",
```

#### `src/mcpm/clients/client_registry.py` (diff)

```diff
+from mcpm.clients.managers.amp import AmpManager
 from mcpm.clients.managers.claude_code import ClaudeCodeManager
 from mcpm.clients.managers.claude_desktop import ClaudeDesktopManager
 from mcpm.clients.managers.cline import ClineManager, RooCodeManager
@@ -41,6 +42,7 @@
     # Dictionary mapping client keys to manager classes
     _CLIENT_MANAGERS = {
+        "amp": AmpManager,
         "claude-code": ClaudeCodeManager,
         "claude-desktop": ClaudeDesktopManager,
         "windsurf": WindsurfManager,
```

#### `tests/test_clients/test_amp.py` (new)

```python
"""Tests for the Sourcegraph Amp client manager."""

import json
import os
import tempfile
from unittest.mock import patch

import pytest

from mcpm.clients.managers.amp import AmpManager


@pytest.fixture
def temp_json_config():
    with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".json") as f:
        json.dump({"amp.mcpServers": {}}, f)
        temp_path = f.name

    yield temp_path
    os.unlink(temp_path)


@pytest.fixture
def amp_manager(temp_json_config):
    return AmpManager(config_path_override=temp_json_config)


def test_default_config_path():
    """Test that the default config path is ~/.config/amp/settings.json"""
    manager = AmpManager()
    assert manager.config_path.endswith(".config/amp/settings.json")


def test_config_path_override(temp_json_config):
    """Test that config_path_override takes precedence over the default path"""
    manager = AmpManager(config_path_override=temp_json_config)
    assert manager.config_path == temp_json_config


def test_uses_dotted_amp_mcpServers_key():
    """Test that Amp uses the literal `amp.mcpServers` key (not nested)"""
    assert AmpManager.configure_key_name == "amp.mcpServers"


def test_get_empty_config(amp_manager):
    """Test that empty config returns the dotted-key shape"""
    empty = amp_manager._get_empty_config()
    assert empty == {"amp.mcpServers": {}}


def test_get_client_info(amp_manager):
    info = amp_manager.get_client_info()
    assert info["name"] == "Sourcegraph Amp"
    assert info["download_url"] == "https://ampcode.com"
    assert "amp" in info["description"].lower()
    assert "config_file" in info


def test_is_client_installed_when_amp_on_path(amp_manager):
    """Test that is_client_installed returns True when amp binary is on PATH"""
    with patch("mcpm.clients.managers.amp.shutil.which", return_value="/usr/local/bin/amp"):
        assert amp_manager.is_client_installed() is True


def test_is_client_installed_when_amp_missing(amp_manager):
    """Test that is_client_installed returns False when amp binary is missing"""
    with patch("mcpm.clients.managers.amp.shutil.which", return_value=None):
        assert amp_manager.is_client_installed() is False


def test_add_and_list_server(amp_manager):
    """Test the add_server / list_servers / get_server lifecycle"""
    success = amp_manager.add_server(
        {
            "name": "test-server",
            "type": "stdio",
            "command": "npx",
            "args": ["-y", "@modelcontextprotocol/server-test"],
        },
        "test-server",
    )
    assert success

    servers = amp_manager.list_servers()
    assert "test-server" in servers

    server = amp_manager.get_server("test-server")
    assert server is not None
    assert server.name == "test-server"


def test_remove_server(amp_manager):
    """Test the remove_server lifecycle"""
    amp_manager.add_server(
        {"name": "test-server", "type": "stdio", "command": "npx"},
        "test-server",
    )
    assert amp_manager.remove_server("test-server") is True
    assert amp_manager.get_server("test-server") is None


def test_load_config_returns_empty_when_file_missing():
    """Test that _load_config returns empty config shape when file doesn't exist"""
    with tempfile.TemporaryDirectory() as tmpdir:
        missing_path = os.path.join(tmpdir, "nonexistent.json")
        manager = AmpManager(config_path_override=missing_path)
        config = manager._load_config()
        assert config == {"amp.mcpServers": {}}


def test_preserves_other_keys_when_adding_server():
    """Test that adding a server preserves unrelated top-level keys
    (e.g. amp.theme, amp.modelOverrides) so we don't clobber Amp settings."""
    with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".json") as f:
        json.dump({"amp.mcpServers": {}, "amp.theme": "dark", "amp.foo": "bar"}, f)
        temp_path = f.name

    try:
        manager = AmpManager(config_path_override=temp_path)
        manager.add_server(
            {"name": "test-server", "type": "stdio", "command": "npx"},
            "test-server",
        )
        with open(temp_path) as f:
            config = json.load(f)
        # amp.mcpServers got the new server
        assert "test-server" in config["amp.mcpServers"]
        # Unrelated keys survived
        assert config["amp.theme"] == "dark"
        assert config["amp.foo"] == "bar"
    finally:
        os.unlink(temp_path)
```

### Why it matters

Once this lands, agentbrew (and any other downstream tool that delegates to mcpm) can call `mcpm install <server> --client amp` and `mcpm client edit amp --add-server <server>` end-to-end. Today agentbrew keeps a [native carve-out](https://github.com/expertnetwrk-portal/agentbrew/blob/main/src/core/mcp-agent-map.ts) for amp because mcpm doesn't have an adapter — that ~80 LOC carve-out becomes deletable on merge.

### Note on the dotted key name

Amp groups its settings file under flat keys with literal dots — `amp.mcpServers`, `amp.theme`, `amp.modelOverrides`, etc. This is NOT a nested object structure: the JSON file is `{"amp.mcpServers": {...}, "amp.theme": "dark", ...}`, not `{"amp": {"mcpServers": {...}, "theme": "dark"}}`. Python's dict access (`config["amp.mcpServers"]`) handles the dotted key without any special-casing — same as VSCode's `"servers"` and OpenCode's `"mcp"` key in the existing adapters. The `configure_key_name = "amp.mcpServers"` override on `JSONClientManager` is all that's needed.

The harm of not landing this is bounded (amp users can configure MCP manually), but the fix is mechanical, the test surface mirrors the slice 6a opencode adapter ([#327](https://github.com/pathintegral-institute/mcpm.sh/pull/327)), and it parallels the kiro adapter PR (#328).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sourcegraph Amp is now integrated as a supported client manager
  * Users can manage MCP servers through Sourcegraph Amp's configuration interface
  * Automatic detection of Amp installation on the system

* **Tests**
  * Added extensive test coverage for the new Amp client integration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->