### PR TITLE
Add NotFair (Google Ads MCP)

### DIFF
--- a/mcp-registry/servers/notfair.json
+++ b/mcp-registry/servers/notfair.json
@@ -1,0 +1,57 @@
+{
+  "display_name": "NotFair Google Ads MCP",
+  "license": "Proprietary",
+  "tags": [
+    "google-ads",
+    "marketing",
+    "advertising",
+    "ads",
+    "ppc",
+    "campaign-management"
+  ],
+  "name": "notfair",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/nowork-studio/toprank"
+  },
+  "homepage": "https://notfair.co",
+  "author": {
+    "name": "nowork-studio",
+    "url": "https://notfair.co"
+  },
+  "description": "Google Ads MCP server. Connect Claude and other AI agents to a Google Ads account: diagnose campaign performance (CPA, ROAS, search-term waste, quality scores), recommend optimizations (bids, budgets, negatives, ad copy), and execute approved changes via the Google Ads API with a built-in human-approval gate.",
+  "categories": [
+    "Professional Apps",
+    "Analytics"
+  ],
+  "installations": {
+    "http": {
+      "type": "http",
+      "url": "https://notfair.co/api/mcp/google_ads",
+      "description": "Hosted streamable-HTTP MCP server. Sign in at notfair.co to authorize a Google Ads account, then connect via this URL."
+    }
+  },
+  "examples": [
+    {
+      "title": "Account audit",
+      "description": "Quick performance and waste audit",
+      "prompt": "Audit my Google Ads account and find quick wins."
+    },
+    {
+      "title": "Search-term waste",
+      "description": "Find wasted spend on irrelevant queries",
+      "prompt": "Show me search terms with high spend and zero conversions over the last 30 days."
+    },
+    {
+      "title": "Bid optimization",
+      "description": "Adjust bids based on performance",
+      "prompt": "Recommend bid changes for my top 20 keywords by spend, then execute the approved changes."
+    },
+    {
+      "title": "Negative keyword cleanup",
+      "description": "Add negatives for wasteful queries",
+      "prompt": "Find irrelevant search terms wasting budget and add them as negative keywords."
+    }
+  ],
+  "is_official": true
+}


### PR DESCRIPTION
Adds NotFair to the registry. It's a Google Ads MCP server that lets Claude and other AI agents diagnose campaign performance, recommend optimizations, and execute approved changes via the Google Ads API with a built-in human-approval gate.

Source: github.com/nowork-studio/toprank
Registry: io.github.nowork-studio/notfair (active in the official MCP registry)
Endpoint: streamable-http at notfair.co/api/mcp/google_ads

Free tier available. The manifest follows the schema and uses the http installation type since it's a hosted server. Happy to adjust the format or fields if you'd prefer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* Added official NotFair Google Ads MCP server for auditing and optimizing Google Ads campaigns, including account audits, search term waste analysis, bid optimization, and negative keyword cleanup.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pathintegral-institute/mcpm.sh/pull/334)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->