### PR TITLE
Add Xquik MCP registry manifest

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version: '3.11'
       - name: Install uv
         uses: astral-sh/setup-uv@v5
         with:
@@ -47,7 +47,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version: '3.11'
       - name: Install uv
         uses: astral-sh/setup-uv@v5
         with:
@@ -55,4 +55,4 @@ jobs:
       - name: Check code style with ruff
         run: |
           uv sync --group dev
-          uv run ruff check src/ tests/ 
+          uv run ruff check src/ tests/

--- a/mcp-registry/servers/xquik.json
+++ b/mcp-registry/servers/xquik.json
@@ -1,0 +1,104 @@
+{
+  "name": "xquik",
+  "display_name": "Xquik MCP Server",
+  "description": "Hosted MCP server for X data, search, user lookup, monitoring, webhooks, and write actions through the Xquik API. Xquik is an independent third-party service and is not affiliated with X Corp.",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Xquik-dev/x-twitter-scraper"
+  },
+  "homepage": "https://docs.xquik.com/mcp/overview",
+  "author": {
+    "name": "Xquik-dev",
+    "url": "https://github.com/Xquik-dev"
+  },
+  "license": "Proprietary",
+  "categories": [
+    "Web Services",
+    "Analytics",
+    "Messaging"
+  ],
+  "tags": [
+    "x",
+    "twitter",
+    "social media",
+    "tweet search",
+    "user lookup",
+    "monitoring",
+    "webhooks",
+    "automation",
+    "remote mcp"
+  ],
+  "arguments": {
+    "XQUIK_API_KEY": {
+      "description": "Xquik API key from https://dashboard.xquik.com/en/account",
+      "required": true,
+      "example": "xq_your_api_key"
+    }
+  },
+  "installations": {
+    "http": {
+      "type": "http",
+      "url": "https://xquik.com/mcp",
+      "headers": {
+        "Authorization": "Bearer ${XQUIK_API_KEY}"
+      },
+      "description": "Connect to the hosted Xquik MCP server using Streamable HTTP.",
+      "recommended": true
+    }
+  },
+  "tools": [
+    {
+      "name": "explore",
+      "description": "Search the Xquik API catalog before making live API calls. Runs against an in-memory catalog only, does not make network calls, and is limited by a 60 second execution timeout. Runtime surface: standard JavaScript built-ins plus read-only spec.endpoints.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string",
+            "description": "JavaScript async arrow function for inputSchema.properties.code that filters the Xquik endpoint catalog. Available globals are standard JavaScript built-ins and spec.endpoints. No filesystem, process, import, credential, fetch, or outbound network access is available."
+          }
+        },
+        "required": [
+          "code"
+        ]
+      }
+    },
+    {
+      "name": "xquik",
+      "description": "Execute authenticated Xquik API calls for X/Twitter data, publishing, monitors, events, webhooks, and account workflows. Runs in a restricted server-side JavaScript runtime with a 60 second execution timeout. Runtime surface: standard JavaScript built-ins, spec.endpoints, and xquik.request. Network access is limited to Xquik API requests made through xquik.request.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string",
+            "description": "JavaScript async arrow function for inputSchema.properties.code that calls xquik.request(path, options). Authentication is injected by the server. Available globals are standard JavaScript built-ins, spec.endpoints, and xquik.request. Code cannot read credentials, access the filesystem or process, import modules, call fetch directly, or contact external hosts directly; only xquik.request can reach the Xquik API."
+          }
+        },
+        "required": [
+          "code"
+        ]
+      }
+    }
+  ],
+  "resources": [],
+  "prompts": [],
+  "examples": [
+    {
+      "title": "Search Tweets",
+      "description": "Find recent X posts that match a query.",
+      "prompt": "Use Xquik to search recent tweets about MCP registries."
+    },
+    {
+      "title": "Look Up A User",
+      "description": "Fetch normalized profile data for an X user.",
+      "prompt": "Use Xquik to look up the X profile for @xquik."
+    },
+    {
+      "title": "Monitor A Keyword",
+      "description": "Create an account or keyword monitor when the API key has access.",
+      "prompt": "Use Xquik to monitor new X posts mentioning my product keyword."
+    }
+  ],
+  "is_official": false,
+  "is_archived": false
+}


### PR DESCRIPTION
## Summary

- Add a validated Xquik remote MCP manifest.
- Describe the hosted Streamable HTTP endpoint and API-key setup.
- Align CI with the project's declared Python 3.11 minimum.

## Xquik Manifest

- Connect to `https://xquik.com/mcp` over Streamable HTTP.
- Authenticate with `Authorization: Bearer ${XQUIK_API_KEY}`.
- Discover the API catalog through `explore`.
- Execute authenticated API operations through `xquik`.
- Document the 60-second execution timeout and restricted runtime surface.
- Mark the hosted service license accurately as proprietary.
- State that Xquik is independent and not affiliated with X Corp.

The manifest keeps `is_official` false because this registry lacks a documented approval process for that trust flag.

## Independent Repository Fix

Both CI jobs previously installed Python 3.10 despite `pyproject.toml` requiring Python 3.11 or newer. This change sets test and lint jobs to Python 3.11, the supported minimum. It also removes trailing whitespace from the workflow.

## Validation

- 382 registry manifests validate, including `xquik: Valid`.
- 292 tests pass and 6 skip on Python 3.11.
- Ruff passes.
- The workflow parses as valid YAML and both jobs select Python 3.11.
- JSON formatting and `git diff --check` pass.
- The public branch contains exactly 1 verified SSH-signed commit.

Both previous CodeRabbit review threads remain addressed and resolved.
