### PR TITLE
feat: add StandupCraft and StatusCraft MCP server manifests

### DIFF
--- a/mcp-registry/servers/standupcraft.json
+++ b/mcp-registry/servers/standupcraft.json
@@ -1,0 +1,103 @@
+{
+  "name": "standupcraft",
+  "display_name": "StandupCraft",
+  "description": "MCP server that reads your git commits and GitHub activity to generate daily standups, weekly client reports, and sprint retros inside Claude Desktop. Scans local git repos and GitHub activity for a date range, then drafts structured standup notes, client-ready progress reports, or sprint retrospectives in your own words. No API key required, runs entirely locally.",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jabbawocky/standupcraft"
+  },
+  "homepage": "https://github.com/jabbawocky/standupcraft",
+  "author": {
+    "name": "jabbawocky"
+  },
+  "license": "MIT",
+  "categories": ["Productivity", "Developer Tools"],
+  "tags": [
+    "standup",
+    "git",
+    "github",
+    "reports",
+    "developer-tools",
+    "claude-desktop",
+    "mcp-server",
+    "productivity",
+    "agile"
+  ],
+  "installations": {
+    "npm": {
+      "type": "npm",
+      "command": "npx",
+      "args": [
+        "-y",
+        "github:jabbawocky/standupcraft"
+      ],
+      "description": "Run directly via npx — no global install needed",
+      "env": {
+        "GITHUB_TOKEN": {
+          "description": "GitHub personal access token for fetching GitHub activity (optional — git activity works without it)",
+          "required": false
+        },
+        "REPOS_DIR": {
+          "description": "Directory to scan for git repositories (default: home directory)",
+          "required": false
+        }
+      }
+    }
+  },
+  "examples": [
+    {
+      "title": "Generate a daily standup",
+      "description": "Create a standup note from today's git commits and GitHub activity",
+      "prompt": "Generate my standup for today"
+    },
+    {
+      "title": "Write a weekly client report",
+      "description": "Summarize a week of commits into a client-ready progress report",
+      "prompt": "Write a weekly client report for the past 7 days"
+    },
+    {
+      "title": "Sprint retrospective",
+      "description": "Draft a sprint retro from two weeks of activity",
+      "prompt": "Draft a sprint retrospective for the past two weeks"
+    }
+  ],
+  "tools": [
+    {
+      "name": "generate_standup",
+      "description": "Generate a daily standup note from git commits and GitHub activity",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "date": {
+            "type": "string",
+            "description": "Date to generate standup for (ISO format, defaults to today)"
+          }
+        }
+      }
+    },
+    {
+      "name": "generate_report",
+      "description": "Generate a weekly client report or sprint retrospective from git and GitHub activity",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "start_date": {
+            "type": "string",
+            "description": "Start date for the report period (ISO format)"
+          },
+          "end_date": {
+            "type": "string",
+            "description": "End date for the report period (ISO format)"
+          },
+          "report_type": {
+            "type": "string",
+            "description": "Type of report: 'client' for client report, 'retro' for sprint retrospective"
+          }
+        }
+      }
+    }
+  ],
+  "prompts": [],
+  "resources": [],
+  "is_official": false
+}

--- a/mcp-registry/servers/statuscraft.json
+++ b/mcp-registry/servers/statuscraft.json
@@ -1,0 +1,101 @@
+{
+  "name": "statuscraft",
+  "display_name": "StatusCraft",
+  "description": "MCP server that checks the live status of 141 major software services in real time. Ask your AI agent 'is GitHub down?' or 'what's wrong with Stripe?' and get a live answer pulled directly from official status pages, including full incident detail when something is broken. Services include AWS, Azure, Cloudflare, GitHub, Anthropic, OpenAI, Stripe, Vercel, Netlify, Linear, and more. No API key required.",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jabbawocky/statuscraft"
+  },
+  "homepage": "https://github.com/jabbawocky/statuscraft",
+  "author": {
+    "name": "jabbawocky"
+  },
+  "license": "MIT",
+  "categories": ["Monitoring", "Developer Tools"],
+  "tags": [
+    "status",
+    "monitoring",
+    "devops",
+    "uptime",
+    "incident",
+    "claude-desktop",
+    "mcp-server",
+    "infrastructure",
+    "observability"
+  ],
+  "installations": {
+    "npm": {
+      "type": "npm",
+      "command": "npx",
+      "args": [
+        "-y",
+        "github:jabbawocky/statuscraft"
+      ],
+      "description": "Run directly via npx — no global install needed"
+    }
+  },
+  "examples": [
+    {
+      "title": "Check if a service is down",
+      "description": "Get the live status of any tracked service",
+      "prompt": "Is GitHub down right now?"
+    },
+    {
+      "title": "Check multiple services at once",
+      "description": "Get status for several services in parallel",
+      "prompt": "Check the status of GitHub, AWS, and Stripe"
+    },
+    {
+      "title": "Get incident details",
+      "description": "When a service is non-operational, get full incident detail",
+      "prompt": "What's the current Cloudflare incident about?"
+    }
+  ],
+  "tools": [
+    {
+      "name": "get_status",
+      "description": "Check the live status of a single service — returns normalized status and incident detail when non-operational",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "service": {
+            "type": "string",
+            "description": "Service ID or name to check (e.g. 'github', 'aws', 'stripe')"
+          }
+        },
+        "required": ["service"]
+      }
+    },
+    {
+      "name": "check_multiple",
+      "description": "Check the status of multiple services in parallel",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "services": {
+            "type": "array",
+            "items": {"type": "string"},
+            "description": "List of service IDs or names to check"
+          }
+        },
+        "required": ["services"]
+      }
+    },
+    {
+      "name": "list_services",
+      "description": "List all 141 tracked services with their IDs and categories",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "category": {
+            "type": "string",
+            "description": "Optional category filter (e.g. 'cloud', 'ai', 'payments')"
+          }
+        }
+      }
+    }
+  ],
+  "prompts": [],
+  "resources": [],
+  "is_official": false
+}


### PR DESCRIPTION
Adds two free MCP servers to the registry:

**StandupCraft** (`standupcraft`)
- Reads git commits + GitHub activity to generate daily standups, weekly client reports, and sprint retros inside Claude Desktop
- No API key required, runs locally
- GitHub: https://github.com/jabbawocky/standupcraft
- Install: `npx -y github:jabbawocky/standupcraft`

**StatusCraft** (`statuscraft`)
- Real-time status monitoring for 141 major services (AWS, GitHub, Stripe, Cloudflare, Anthropic, OpenAI, etc.)
- Ask Claude "is GitHub down?" and get a live answer with full incident detail
- No API key required, runs locally
- GitHub: https://github.com/jabbawocky/statuscraft
- Install: `npx -y github:jabbawocky/statuscraft`

Both are MIT licensed, free, and can be run with a single `npx` command — no global install needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Registered StandupCraft MCP server to help teams generate standup summaries and detailed reports with flexible date ranges, supporting both client-specific reports and sprint retrospectives
  * Registered StatusCraft MCP server to monitor system health by checking individual and multiple service statuses and maintaining a complete inventory of all services

<!-- end of auto-generated comment: release notes by coderabbit.ai -->