### PR TITLE
Add server: openrouter-fusion

### DIFF
--- a/mcp-registry/servers/openrouter-fusion.json
+++ b/mcp-registry/servers/openrouter-fusion.json
@@ -1,7 +1,7 @@
 {
   "name": "openrouter-fusion",
   "display_name": "OpenRouter Fusion",
-  "description": "Multi-model deliberation for high-stakes answers via OpenRouter Fusion: a panel of models answers in parallel (with web search/fetch), then a judge (Opus) synthesizes consensus, contradictions and blind spots into one best answer. Ships named presets (quality, budget, research, research-eco, maths, medecine, code) with per-config reasoning effort / temperature / web-loop cap, a live per-preset cost estimate from OpenRouter prices, and an async start/poll flow so long deliberations never hit a client timeout.",
+  "description": "Multi-model deliberation for high-stakes answers via OpenRouter Fusion: a panel of models answers in parallel (with web search/fetch), then a judge (Opus) synthesizes consensus, contradictions and blind spots into one best answer. Ships named presets (quality, budget, research, research-eco, maths, medicine, code) with per-config reasoning effort / temperature / web-loop cap, a live per-preset cost estimate from OpenRouter prices, and an async start/poll flow so long deliberations never hit a client timeout.",
   "repository": {
     "type": "git",
     "url": "https://github.com/tboome33/openrouter-fusion-mcp"
@@ -55,7 +55,7 @@
       "env": {
         "OPENROUTER_API_KEY": "${OPENROUTER_API_KEY}"
       },
-      "description": "Runs the published npm package via npx. Presets 'quality' and 'budget' work out-of-the-box; the custom presets (research, research-eco, maths, medecine, code) are added as extra OPENROUTER_FUSION_<NAME> env vars — paste-ready values are in the repo's fusion-env-vars.json.",
+      "description": "Runs the published npm package via npx. Presets 'quality' and 'budget' work out-of-the-box; the custom presets (research, research-eco, maths, medicine, code) are added as extra OPENROUTER_FUSION_<NAME> env vars — paste-ready values are in the repo's fusion-env-vars.json.",
       "recommended": true
     }
   },
@@ -66,7 +66,7 @@
       "example": "sk-or-v1-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
     },
     "OPENROUTER_FUSION_RESEARCH": {
-      "description": "Optional. A named custom config, as a JSON object. One env var per config: OPENROUTER_FUSION_<SUFFIX>; the config name comes from the JSON `name` field (e.g. \"research-eco\"), falling back to the lowercased suffix. Built-in configs 'quality' and 'budget' need no env var. Fields: analysis_models (panel), judge (orchestrator), reasoning_effort (xhigh|high|medium|low|minimal|none), temperature (null = model default), max_tool_calls (1-16, caps the web loop; default 8), optional system. More ready-made presets (research-eco, maths, medecine, code) are in the repo's fusion-env-vars.json.",
+      "description": "Optional. A named custom config, as a JSON object. One env var per config: OPENROUTER_FUSION_<SUFFIX>; the config name comes from the JSON `name` field (e.g. \"research-eco\"), falling back to the lowercased suffix. Built-in configs 'quality' and 'budget' need no env var. Fields: analysis_models (panel), judge (orchestrator), reasoning_effort (xhigh|high|medium|low|minimal|none), temperature (null = model default), max_tool_calls (1-16, caps the web loop; default 8), optional system. More ready-made presets (research-eco, maths, medicine, code) are in the repo's fusion-env-vars.json.",
       "required": false,
       "example": "{\"name\":\"research\",\"analysis_models\":[\"~anthropic/claude-opus-latest\",\"openai/gpt-5.5\",\"~google/gemini-pro-latest\",\"deepseek/deepseek-v4-pro\"],\"judge\":\"~anthropic/claude-opus-latest\",\"reasoning_effort\":\"high\",\"temperature\":null,\"max_tool_calls\":8}"
     },
@@ -80,10 +80,10 @@
       "required": false,
       "example": "{\"name\":\"maths\",\"analysis_models\":[\"openai/gpt-5.5\",\"~google/gemini-pro-latest\",\"deepseek/deepseek-v4-pro\",\"z-ai/glm-5.2\"],\"judge\":\"~anthropic/claude-opus-latest\",\"reasoning_effort\":\"xhigh\",\"temperature\":null,\"max_tool_calls\":8}"
     },
-    "OPENROUTER_FUSION_MEDECINE": {
-      "description": "Optional. Ready-made \"medecine\" preset (French clinical-reasoning aid, cautious Opus judge - decision support, not a diagnosis). Full value incl. system prompt in fusion-env-vars.json.",
+    "OPENROUTER_FUSION_MEDICINE": {
+      "description": "Optional. Ready-made \"medicine\" preset (French clinical-reasoning aid, cautious Opus judge - decision support, not a diagnosis). Full value incl. system prompt in fusion-env-vars.json.",
       "required": false,
-      "example": "{\"name\":\"medecine\",\"analysis_models\":[\"~anthropic/claude-opus-latest\",\"openai/gpt-5.5\",\"~google/gemini-pro-latest\"],\"judge\":\"~anthropic/claude-opus-latest\",\"reasoning_effort\":\"high\",\"temperature\":null,\"max_tool_calls\":8}"
+      "example": "{\"name\":\"medicine\",\"analysis_models\":[\"~anthropic/claude-opus-latest\",\"openai/gpt-5.5\",\"~google/gemini-pro-latest\"],\"judge\":\"~anthropic/claude-opus-latest\",\"reasoning_effort\":\"high\",\"temperature\":null,\"max_tool_calls\":8}"
     },
     "OPENROUTER_FUSION_CODE": {
       "description": "Optional. Ready-made \"code\" preset (architecture/review, not raw code generation). Full value incl. system prompt in fusion-env-vars.json.",

--- a/mcp-registry/servers/openrouter-fusion.json
+++ b/mcp-registry/servers/openrouter-fusion.json
@@ -66,9 +66,29 @@
       "example": "sk-or-v1-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
     },
     "OPENROUTER_FUSION_RESEARCH": {
-      "description": "Optional. A named custom config, as a JSON object. One env var per config: OPENROUTER_FUSION_<NAME> registers a config named <name>. Built-in configs 'quality' and 'budget' need no env var. Fields: analysis_models (panel), judge (orchestrator), reasoning_effort (xhigh|high|medium|low|minimal|none), temperature (null = model default), max_tool_calls (1-16, caps the web loop; default 8), optional system. More ready-made presets (research-eco, maths, medecine, code) are in the repo's fusion-env-vars.json.",
+      "description": "Optional. A named custom config, as a JSON object. One env var per config: OPENROUTER_FUSION_<SUFFIX>; the config name comes from the JSON `name` field (e.g. \"research-eco\"), falling back to the lowercased suffix. Built-in configs 'quality' and 'budget' need no env var. Fields: analysis_models (panel), judge (orchestrator), reasoning_effort (xhigh|high|medium|low|minimal|none), temperature (null = model default), max_tool_calls (1-16, caps the web loop; default 8), optional system. More ready-made presets (research-eco, maths, medecine, code) are in the repo's fusion-env-vars.json.",
       "required": false,
       "example": "{\"name\":\"research\",\"analysis_models\":[\"~anthropic/claude-opus-latest\",\"openai/gpt-5.5\",\"~google/gemini-pro-latest\",\"deepseek/deepseek-v4-pro\"],\"judge\":\"~anthropic/claude-opus-latest\",\"reasoning_effort\":\"high\",\"temperature\":null,\"max_tool_calls\":8}"
+    },
+    "OPENROUTER_FUSION_RESEARCHECO": {
+      "description": "Optional. Ready-made \"research-eco\" preset (cheaper panel, Opus judge). Same field shape as OPENROUTER_FUSION_RESEARCH; full paste-ready value in the repo's fusion-env-vars.json.",
+      "required": false,
+      "example": "{\"name\":\"research-eco\",\"analysis_models\":[\"~google/gemini-flash-latest\",\"~moonshotai/kimi-latest\",\"deepseek/deepseek-v4-pro\"],\"judge\":\"~anthropic/claude-opus-latest\",\"reasoning_effort\":\"high\",\"temperature\":null,\"max_tool_calls\":8}"
+    },
+    "OPENROUTER_FUSION_MATHS": {
+      "description": "Optional. Ready-made \"maths\" preset (diverse reasoner panel, xhigh effort). Full value incl. system prompt in fusion-env-vars.json.",
+      "required": false,
+      "example": "{\"name\":\"maths\",\"analysis_models\":[\"openai/gpt-5.5\",\"~google/gemini-pro-latest\",\"deepseek/deepseek-v4-pro\",\"z-ai/glm-5.2\"],\"judge\":\"~anthropic/claude-opus-latest\",\"reasoning_effort\":\"xhigh\",\"temperature\":null,\"max_tool_calls\":8}"
+    },
+    "OPENROUTER_FUSION_MEDECINE": {
+      "description": "Optional. Ready-made \"medecine\" preset (French clinical-reasoning aid, cautious Opus judge - decision support, not a diagnosis). Full value incl. system prompt in fusion-env-vars.json.",
+      "required": false,
+      "example": "{\"name\":\"medecine\",\"analysis_models\":[\"~anthropic/claude-opus-latest\",\"openai/gpt-5.5\",\"~google/gemini-pro-latest\"],\"judge\":\"~anthropic/claude-opus-latest\",\"reasoning_effort\":\"high\",\"temperature\":null,\"max_tool_calls\":8}"
+    },
+    "OPENROUTER_FUSION_CODE": {
+      "description": "Optional. Ready-made \"code\" preset (architecture/review, not raw code generation). Full value incl. system prompt in fusion-env-vars.json.",
+      "required": false,
+      "example": "{\"name\":\"code\",\"analysis_models\":[\"openai/gpt-5.5\",\"~anthropic/claude-opus-latest\",\"deepseek/deepseek-v4-pro\",\"z-ai/glm-5.2\"],\"judge\":\"~anthropic/claude-opus-latest\",\"reasoning_effort\":\"high\",\"temperature\":null,\"max_tool_calls\":8}"
     },
     "OPENROUTER_FUSION_DEFAULT_REASONING": {
       "description": "Optional. Global default reasoning effort applied to any config that doesn't set its own. Defaults to 'high'.",

--- a/mcp-registry/servers/openrouter-fusion.json
+++ b/mcp-registry/servers/openrouter-fusion.json
@@ -1,0 +1,167 @@
+{
+  "name": "openrouter-fusion",
+  "display_name": "OpenRouter Fusion",
+  "description": "Multi-model deliberation for high-stakes answers via OpenRouter Fusion: a panel of models answers in parallel (with web search/fetch), then a judge (Opus) synthesizes consensus, contradictions and blind spots into one best answer. Ships named presets (quality, budget, research, research-eco, maths, medecine, code) with per-config reasoning effort / temperature / web-loop cap, a live per-preset cost estimate from OpenRouter prices, and an async start/poll flow so long deliberations never hit a client timeout.",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/tboome33/openrouter-fusion-mcp"
+  },
+  "homepage": "https://github.com/tboome33/openrouter-fusion-mcp",
+  "author": {
+    "name": "tboome33"
+  },
+  "license": "MIT",
+  "categories": [
+    "AI Systems",
+    "MCP Tools"
+  ],
+  "tags": [
+    "openrouter",
+    "fusion",
+    "multi-model",
+    "llm",
+    "deliberation",
+    "ensemble",
+    "judge",
+    "research",
+    "async",
+    "cost-estimate"
+  ],
+  "examples": [
+    {
+      "title": "List the configs with their cost",
+      "description": "Show every Fusion preset (quality, budget, research, …) with its panel, judge, reasoning effort and estimated cost range, then pick one.",
+      "prompt": "List the available Fusion configs with their estimated cost."
+    },
+    {
+      "title": "Start a deep-research deliberation",
+      "description": "Run the diversified frontier panel (Opus + GPT + Gemini Pro + DeepSeek, judged by Opus) in the background and get a job id.",
+      "prompt": "Use Fusion (research) to assess whether 'CRSI' is a real, substantiated concept or an empty buzzword."
+    },
+    {
+      "title": "Fetch the result",
+      "description": "Long-poll the job id returned by fusion_start until the synthesized answer is ready.",
+      "prompt": "Get the Fusion result for job_id fj_xxx."
+    }
+  ],
+  "installations": {
+    "npm": {
+      "type": "npm",
+      "command": "npx",
+      "args": [
+        "-y",
+        "openrouter-fusion-mcp"
+      ],
+      "env": {
+        "OPENROUTER_API_KEY": "${OPENROUTER_API_KEY}"
+      },
+      "description": "Runs the published npm package via npx. Presets 'quality' and 'budget' work out-of-the-box; the custom presets (research, research-eco, maths, medecine, code) are added as extra OPENROUTER_FUSION_<NAME> env vars — paste-ready values are in the repo's fusion-env-vars.json.",
+      "recommended": true
+    }
+  },
+  "arguments": {
+    "OPENROUTER_API_KEY": {
+      "description": "Your OpenRouter API key. MUST be an inference key with credit (a provisioning/management key returns 401 'User not found'). Get one at https://openrouter.ai/keys",
+      "required": true,
+      "example": "sk-or-v1-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+    },
+    "OPENROUTER_FUSION_RESEARCH": {
+      "description": "Optional. A named custom config, as a JSON object. One env var per config: OPENROUTER_FUSION_<NAME> registers a config named <name>. Built-in configs 'quality' and 'budget' need no env var. Fields: analysis_models (panel), judge (orchestrator), reasoning_effort (xhigh|high|medium|low|minimal|none), temperature (null = model default), max_tool_calls (1-16, caps the web loop; default 8), optional system. More ready-made presets (research-eco, maths, medecine, code) are in the repo's fusion-env-vars.json.",
+      "required": false,
+      "example": "{\"name\":\"research\",\"analysis_models\":[\"~anthropic/claude-opus-latest\",\"openai/gpt-5.5\",\"~google/gemini-pro-latest\",\"deepseek/deepseek-v4-pro\"],\"judge\":\"~anthropic/claude-opus-latest\",\"reasoning_effort\":\"high\",\"temperature\":null,\"max_tool_calls\":8}"
+    },
+    "OPENROUTER_FUSION_DEFAULT_REASONING": {
+      "description": "Optional. Global default reasoning effort applied to any config that doesn't set its own. Defaults to 'high'.",
+      "required": false,
+      "example": "high"
+    }
+  },
+  "tools": [
+    {
+      "name": "fusion_list",
+      "description": "List the available Fusion configs — each with name, label, panel, judge, reasoning_effort, temperature, max_tool_calls, a relative cost_tier (€/€€/€€€) and a cost_estimate {low, high, usd_per_prompt_token} computed from live OpenRouter prices. Call this FIRST when the user wants Fusion but hasn't named a config: present them, recommend one, and let the user pick.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {}
+      }
+    },
+    {
+      "name": "fusion_start",
+      "description": "Start an OpenRouter Fusion deliberation in the background and return a job_id immediately (never times out). Pick a config with preset:'<name>' (default: quality). reasoning_effort, temperature and max_tool_calls default to the config's; override per call.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "prompt": {
+            "type": "string",
+            "description": "The question or task to deliberate on."
+          },
+          "preset": {
+            "type": "string",
+            "description": "Config name from fusion_list (quality, budget, or a custom one). Default: quality."
+          },
+          "system": {
+            "type": "string",
+            "description": "Optional system instruction (overrides the config's)."
+          },
+          "reasoning_effort": {
+            "type": "string",
+            "enum": [
+              "xhigh",
+              "high",
+              "medium",
+              "low",
+              "minimal",
+              "none"
+            ],
+            "description": "Override the config's reasoning effort."
+          },
+          "temperature": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 2,
+            "description": "Override the config's sampling temperature (omit = config/model default)."
+          },
+          "analysis_models": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "minItems": 1,
+            "maxItems": 8,
+            "description": "Override the config's panel (1-8 OpenRouter model slugs)."
+          },
+          "judge_model": {
+            "type": "string",
+            "description": "Override the config's judge/orchestrator model."
+          },
+          "max_tool_calls": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 16,
+            "description": "Cap the panel/judge web-search loop. Default 8; do not set very low (e.g. 1) or a hungry judge can end on a tool call with no final text."
+          }
+        },
+        "required": [
+          "prompt"
+        ]
+      }
+    },
+    {
+      "name": "fusion_result",
+      "description": "Fetch the result of a fusion_start job. Long-polls ~45s: returns the synthesized answer when ready, or {status:'running'} (call again with the same job_id).",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "job_id": {
+            "type": "string",
+            "description": "The job_id returned by fusion_start."
+          }
+        },
+        "required": [
+          "job_id"
+        ]
+      }
+    }
+  ],
+  "is_official": false
+}


### PR DESCRIPTION
## Add server: `openrouter-fusion`

Adds a new entry to `mcp-registry/servers/openrouter-fusion.json`.

**OpenRouter Fusion** is a multi-model deliberation MCP server: a panel of models answers a prompt in parallel (with web search/fetch), then a judge (Claude Opus) synthesizes consensus, contradictions and blind spots into a single best answer. It ships named presets (quality, budget, research, research-eco, maths, medecine, code) with per-config reasoning effort / temperature / web-loop cap, a live per-preset cost estimate computed from OpenRouter prices, and an async `start`/`poll` flow so long deliberations never hit a client timeout.

- **Package (npm):** `openrouter-fusion-mcp` — install via `npx -y openrouter-fusion-mcp`
- **Repository:** https://github.com/tboome33/openrouter-fusion-mcp
- **License:** MIT
- **Tools:** `fusion_list`, `fusion_start`, `fusion_result`
- **Required env:** `OPENROUTER_API_KEY` (an OpenRouter inference key with credit)

The manifest validates against `mcp-registry/schema/server-schema.json` (all required fields present, `name` matches the kebab-case pattern, categories drawn from the allowed enum: `AI Systems`, `MCP Tools`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new MCP server registry entry for OpenRouter Fusion.
  * Introduced tools to list available Fusion configurations, start an async Fusion job, and fetch the synthesized result using a `job_id`.
  * Documented setup and configuration, including a required API key, optional presets/custom Fusion config via environment variables, and a global default reasoning option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->