### PR TITLE
feat(registry): add CitedSpy server configuration to registry

### DIFF
--- a/mcp-registry/servers/citedspy.json
+++ b/mcp-registry/servers/citedspy.json
@@ -1,0 +1,33 @@
+{
+  "name": "citedspy",
+  "display_name": "CitedSpy",
+  "description": "Connect AI tools to your CitedSpy workspace to read brands, prompts, runs, citations, and analytics.",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/citedspy/citedspy"
+  },
+  "homepage": "https://mcp.citedspy.com/mcp",
+  "author": {
+    "name": "CitedSpy"
+  },
+  "license": "MIT",
+  "categories": [
+    "Analytics",
+    "Productivity"
+  ],
+  "tags": [
+    "citedspy",
+    "analytics",
+    "citations",
+    "prompts",
+    "brands"
+  ],
+  "installations": {
+    "http": {
+      "type": "http",
+      "url": "https://mcp.citedspy.com/mcp",
+      "description": "Connect to the CitedSpy MCP endpoint over streamable HTTP. Authentication uses a one-time browser OAuth flow and an API key.",
+      "recommended": true
+    }
+  }
+}


### PR DESCRIPTION
### 📝 Description
This PR adds the **CitedSpy** MCP server to the community registry. 

CitedSpy is an AI visibility tracker. This server allows AI assistants (like Claude, Cursor, and Codex) to connect directly to a user's CitedSpy workspace. Once connected, the AI can read brands, prompts, runs, citations, and analytics, as well as create tracking prompts or trigger new runs natively within the chat interface.

### ⚙️ Server Configuration
* **Name:** `citedspy`
* **Type:** `remote` (Streamable HTTP/SSE)
* **URL:** `https://mcp.citedspy.com/mcp`
* **Authentication:** Uses a remote OAuth flow. It requires a one-time browser authorization using a CitedSpy API key (`cspy_...`).

### ✅ Local Testing & Validation
* [x] Added the server locally to the MCPM global configuration.
* [x] Linked the server to a profile and successfully integrated it into Cursor via the `mcpm client edit cursor` command.
* [x] Successfully triggered and completed the browser-based OAuth flow directly from the Cursor client.
* [x] Verified the AI can successfully execute tools (e.g., `list_brands`) using the authorized connection.

*(Note for reviewers: The MCP Inspector UI currently fails to validate this server due to CitedSpy's specific authentication implementation—it returns a 404 on the `/register` endpoint during dynamic client registration and a CORS 401 on the `OPTIONS` preflight. However, real-world testing via MCPM client integration confirms the server functions flawlessly in standard AI clients.)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new MCP server listing for CitedSpy, including its display details, links, category tags, and supported HTTP connection setup.
  * Included a recommended installation option for connecting to the CitedSpy endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->