### PR TITLE
Add Glif server manifest

### DIFF
--- a/mcp-registry/servers/glif.json
+++ b/mcp-registry/servers/glif.json
@@ -1,0 +1,33 @@
+{
+  "name": "glif",
+  "display_name": "Glif",
+  "description": "Glif's hosted media-generation agent: generate images, video, and audio, transcribe, and chain multi-step media workflows.",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/glifxyz/glif-mcp-server"
+  },
+  "homepage": "https://glif.app/mcp",
+  "author": {
+    "name": "Glif"
+  },
+  "license": "MIT",
+  "categories": [
+    "Media Creation"
+  ],
+  "tags": [
+    "image-generation",
+    "video-generation",
+    "audio-generation",
+    "transcription",
+    "media",
+    "ai"
+  ],
+  "installations": {
+    "http": {
+      "type": "http",
+      "url": "https://glif.app/api/mcp",
+      "description": "Hosted remote server with OAuth",
+      "recommended": true
+    }
+  }
+}


### PR DESCRIPTION
Adds `glif` — hosted media-generation MCP server (images, video, audio). Remote HTTP install: `https://glif.app/api/mcp` with OAuth. Repo: https://github.com/glifxyz/glif-mcp-server

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the Glif server to the registry.
  * Included descriptive metadata, media-generation categories, and supported capabilities.
  * Added a recommended hosted installation option with OAuth authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->