### PR TITLE
Add server: orphograph

### DIFF
--- a/mcp-registry/servers/orphograph.json
+++ b/mcp-registry/servers/orphograph.json
@@ -1,0 +1,57 @@
+{
+  "name": "orphograph",
+  "display_name": "Orphograph",
+  "description": "Anchor a file, folder, or agent-generated output to the Bitcoin blockchain via OpenTimestamps and get a receipt anyone can verify independently. Hashing is local — only the fingerprint crosses the wire, never the file.",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Orphograph/Orphograph"
+  },
+  "homepage": "https://orphograph.com/mcp",
+  "author": {
+    "name": "Orphograph"
+  },
+  "license": "MIT",
+  "categories": [
+    "Dev Tools"
+  ],
+  "tags": [
+    "provenance",
+    "timestamping",
+    "opentimestamps",
+    "bitcoin",
+    "audit-trail",
+    "integrity"
+  ],
+  "installations": {
+    "custom": {
+      "type": "python",
+      "command": "python3",
+      "args": [
+        "orphograph_mcp.py"
+      ],
+      "description": "Single file, Python >=3.9 standard library only, no dependencies. Download with: curl -sSL https://orphograph.com/mcp/orphograph_mcp.py -o orphograph_mcp.py"
+    }
+  },
+  "examples": [
+    {
+      "title": "Prove a file existed before a deadline",
+      "description": "Anchor a contract draft so its existence-by-date can be checked later by someone who does not trust either party's filesystem.",
+      "prompt": "_Anchor ~/contracts/draft-v3.pdf and give me the receipt id_"
+    },
+    {
+      "title": "Anchor an agent's output at the moment it is produced",
+      "description": "Commit the fingerprint of a generated result so the record cannot be revised after the fact.",
+      "prompt": "_Anchor the report you just generated, then tell me its receipt id_"
+    },
+    {
+      "title": "Anchor a whole dataset under one root",
+      "description": "Build an RFC-6962 Merkle manifest over a directory so a single anchored root covers every file in it.",
+      "prompt": "_Anchor the folder ~/datasets/training-set-v2 and show me the Merkle root_"
+    },
+    {
+      "title": "Verify a receipt someone showed you",
+      "description": "Check a receipt against the OpenTimestamps calendars and the Bitcoin chain.",
+      "prompt": "_Verify Orphograph receipt XwTULwlh76PcCst9_"
+    }
+  ]
+}


### PR DESCRIPTION
Adds Orphograph to the registry.

**What it does:** hashes a file, folder, or a string of agent-generated output locally, then commits that fingerprint to the Bitcoin blockchain via OpenTimestamps. The result is a receipt a third party can verify against the public chain — no account, and without trusting the operator or the service.

**Privacy:** the file body never leaves the machine. Only SHA-256/SHA-512 fingerprints are transmitted.

**Tools:** `orphograph_anchor_file`, `orphograph_anchor_folder` (RFC-6962 Merkle manifest, one root per dataset), `orphograph_anchor_output`, `orphograph_verify_receipt`, `orphograph_list_vault`

**Install:** single file, Python >=3.9 standard library only, no dependencies:
`curl -sSL https://orphograph.com/mcp/orphograph_mcp.py -o orphograph_mcp.py`

**Scope, stated plainly:** a receipt establishes that a specific byte string existed by a specific time. Not authorship, not ownership, not correctness, and not copyright registration. No token is involved — nothing minted, nothing for sale; OpenTimestamps and the verifier are open source and work independently of the service.

Verifiable sample receipt: https://orphograph.com/certificate/XwTULwlh76PcCst9

- [x] JSON added at `mcp-registry/servers/orphograph.json`
- [x] Validated locally: `python3 scripts/validate_manifest.py` → `✓ orphograph: Valid`
- [x] Repository is public and MIT licensed
- [x] Install command tested — returns 200, and the downloaded file answers an MCP `initialize` handshake

Prepared with assistance from an AI agent; all facts above were verified against the live endpoints.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the orphograph MCP server to the registry.
  * Included installation details, metadata, classification tags, and example prompts for timestamping, anchoring, and receipt verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->