### PR TITLE
Add OpenPost MCP server

### DIFF
--- a/mcp-registry/servers/openpost.json
+++ b/mcp-registry/servers/openpost.json
@@ -6,7 +6,7 @@
     "type": "git",
     "url": "https://github.com/getopenpost/openpost"
   },
-  "homepage": "https://docs.openpost.social/mcp/",
+  "homepage": "https://docs.openpo.st/mcp/",
   "author": {
     "name": "Rodrigo Dias",
     "url": "https://rgo.pt"
@@ -26,7 +26,7 @@
   "installations": {
     "http": {
       "type": "http",
-      "url": "https://app.openpost.social/mcp",
+      "url": "https://app.openpo.st/mcp",
       "description": "Hosted Streamable HTTP MCP endpoint with OAuth discovery. Sign in to OpenPost and authorize a workspace when prompted.",
       "recommended": true
     }

--- a/mcp-registry/servers/openpost.json
+++ b/mcp-registry/servers/openpost.json
@@ -11,7 +11,7 @@
     "name": "Rodrigo Dias",
     "url": "https://rgo.pt"
   },
-  "license": "AGPL-3.0",
+  "license": "AGPL-3.0-only",
   "categories": [
     "Professional Apps",
     "Productivity"

--- a/mcp-registry/servers/openpost.json
+++ b/mcp-registry/servers/openpost.json
@@ -4,7 +4,7 @@
   "description": "Official MCP server for OpenPost. Inspect connected accounts and media, draft and review social content, schedule or publish it, and manage comments where supported.",
   "repository": {
     "type": "git",
-    "url": "https://github.com/rodrgds/openpost"
+    "url": "https://github.com/getopenpost/openpost"
   },
   "homepage": "https://docs.openpost.social/mcp/",
   "author": {

--- a/mcp-registry/servers/openpost.json
+++ b/mcp-registry/servers/openpost.json
@@ -1,0 +1,57 @@
+{
+  "name": "openpost",
+  "display_name": "OpenPost",
+  "description": "Official MCP server for OpenPost. Inspect connected accounts and media, draft and review social content, schedule or publish it, and manage comments where supported.",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/rodrgds/openpost"
+  },
+  "homepage": "https://docs.openpost.social/mcp/",
+  "author": {
+    "name": "Rodrigo Dias",
+    "url": "https://rgo.pt"
+  },
+  "license": "AGPL-3.0",
+  "categories": [
+    "Professional Apps",
+    "Productivity"
+  ],
+  "tags": [
+    "social-media",
+    "publishing",
+    "scheduling",
+    "content-management",
+    "self-hosted"
+  ],
+  "installations": {
+    "http": {
+      "type": "http",
+      "url": "https://app.openpost.social/mcp",
+      "description": "Hosted Streamable HTTP MCP endpoint with OAuth discovery. Sign in to OpenPost and authorize a workspace when prompted.",
+      "recommended": true
+    }
+  },
+  "examples": [
+    {
+      "title": "Review the schedule",
+      "description": "Inspect upcoming social publications before they go live.",
+      "prompt": "Show me the publications scheduled for this week and flag anything that needs attention."
+    },
+    {
+      "title": "Draft a publication",
+      "description": "Prepare content without publishing it immediately.",
+      "prompt": "Create a draft announcing our latest release for LinkedIn and Bluesky, adapted to each platform."
+    },
+    {
+      "title": "Find the next slot",
+      "description": "Use the workspace schedule to find an available publishing time.",
+      "prompt": "Find the next available slot for this campaign and schedule the approved publication there."
+    },
+    {
+      "title": "Check publication status",
+      "description": "Inspect lifecycle events and provider outcomes.",
+      "prompt": "Check whether yesterday's publication succeeded on every network and show me any failures."
+    }
+  ],
+  "is_official": true
+}


### PR DESCRIPTION
Adds OpenPost's official hosted MCP server to the registry. The manifest uses the repository's HTTP installation type for the OAuth-enabled Streamable HTTP endpoint and includes grounded usage examples.

Validation: `uv run --with jsonschema python scripts/validate_manifest.py` reports `✓ openpost: Valid` across 382 manifests.

Disclosure: I maintain OpenPost.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the official OpenPost MCP server to the registry.
  * Published complete server details, including metadata, categories, tags, licensing, repository, and homepage.
  * Added a recommended HTTP installation option with OAuth discovery support.
  * Included example prompts to demonstrate typical OpenPost usage.
  * Clearly identified the listing as an official server for easier discovery and trust.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->