### PR TITLE
Add Talivia MCP server manifest

### DIFF
--- a/mcp-registry/servers/talivia.json
+++ b/mcp-registry/servers/talivia.json
@@ -1,0 +1,102 @@
+{
+  "name": "talivia",
+  "display_name": "Talivia Revenue Analytics",
+  "description": "Install and verify revenue-first website analytics, track live events, and connect traffic to payment attribution through Talivia.",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/talivia-group/agent"
+  },
+  "homepage": "https://talivia.com/ai-agent-kit",
+  "author": {
+    "name": "Talivia",
+    "url": "https://talivia.com"
+  },
+  "license": "MIT",
+  "categories": [
+    "Analytics",
+    "Web Services",
+    "Professional Apps"
+  ],
+  "tags": [
+    "analytics",
+    "website-analytics",
+    "revenue-attribution",
+    "marketing-attribution",
+    "payments",
+    "tracking"
+  ],
+  "installations": {
+    "http": {
+      "type": "http",
+      "url": "https://talivia.com/mcp",
+      "description": "Hosted Streamable HTTP MCP server with browser-based OAuth."
+    },
+    "npm": {
+      "type": "npm",
+      "command": "npx",
+      "args": [
+        "-y",
+        "@talivia/agent",
+        "mcp"
+      ],
+      "package": "@talivia/agent",
+      "description": "Local stdio MCP server and Agent Kit."
+    }
+  },
+  "tools": [
+    {
+      "name": "talivia_account_status",
+      "description": "Check Talivia authentication and account status."
+    },
+    {
+      "name": "talivia_websites_list",
+      "description": "List websites available in the authenticated Talivia account."
+    },
+    {
+      "name": "talivia_websites_create",
+      "description": "Create a website in Talivia after user confirmation."
+    },
+    {
+      "name": "talivia_tracking_snippet_get",
+      "description": "Get the tracking snippet for a Talivia website."
+    },
+    {
+      "name": "talivia_framework_install_plan_get",
+      "description": "Generate framework-specific tracking installation instructions."
+    },
+    {
+      "name": "talivia_setup_status_get",
+      "description": "Check analytics setup and verification status."
+    },
+    {
+      "name": "talivia_tracker_verify",
+      "description": "Verify that a website sends live tracking events to Talivia."
+    },
+    {
+      "name": "talivia_payment_connect_start",
+      "description": "Start the secure browser flow for payment attribution."
+    },
+    {
+      "name": "talivia_payment_status_get",
+      "description": "Check payment attribution connection status."
+    },
+    {
+      "name": "talivia_checkout_attribution_guide_get",
+      "description": "Get checkout attribution guidance for the selected website."
+    }
+  ],
+  "examples": [
+    {
+      "title": "Install and verify analytics",
+      "description": "Choose a website, install the correct tracking snippet, and verify live events.",
+      "prompt": "Install Talivia analytics on this website and verify that live events are arriving."
+    },
+    {
+      "title": "Connect revenue attribution",
+      "description": "Connect payments and explain which traffic sources become revenue.",
+      "prompt": "Connect payment attribution and show me which campaigns and referrers generate revenue."
+    }
+  ],
+  "is_official": true,
+  "is_archived": false
+}

--- a/mcp-registry/servers/talivia.json
+++ b/mcp-registry/servers/talivia.json
@@ -40,7 +40,8 @@
         "mcp"
       ],
       "package": "@talivia/agent",
-      "description": "Local stdio MCP server and Agent Kit."
+      "description": "Local stdio MCP server and Agent Kit.",
+      "recommended": true
     }
   },
   "tools": [


### PR DESCRIPTION
Talivia is revenue-first website analytics installed and verified by AI agents through MCP.

Official resources:
- Source: https://github.com/talivia-group/agent
- Hosted OAuth MCP: `https://talivia.com/mcp`
- npm: `@talivia/agent` version `0.1.0`
- Official MCP Registry: `io.github.talivia-group/agent`
- Integration guide: https://talivia.com/ai-agent-kit

The server helps agents install tracking, verify live events, connect payment attribution through a secure browser flow, and identify which referrers, campaigns, pages, and customer journeys become revenue.

The manifest includes hosted OAuth and local npm installations, the complete 10-tool list, and example analytics workflows. Validation: the repository's `server-schema.json` accepts the manifest.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Talivia Revenue Analytics to the MCP server registry.
  * Included HTTP and npm installation options.
  * Added analytics and payment-attribution tools, usage examples, and service metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->