### PR TITLE
Add Famulor MCP server

### DIFF
--- a/mcp-registry/servers/famulor.json
+++ b/mcp-registry/servers/famulor.json
@@ -1,0 +1,42 @@
+{
+  "name": "famulor",
+  "display_name": "Famulor",
+  "description": "Hosted MCP server for operating AI assistants and omnichannel communication workflows, including conversation history, calls, campaigns, messaging, knowledge, and automations.",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/bekservice/Famulor-MCP"
+  },
+  "homepage": "https://www.famulor.io",
+  "author": {
+    "name": "BEK Service GmbH",
+    "url": "https://www.famulor.io"
+  },
+  "license": "Proprietary",
+  "categories": [
+    "Productivity",
+    "Messaging",
+    "Professional Apps",
+    "AI Systems"
+  ],
+  "tags": [
+    "voice-ai",
+    "assistants",
+    "communication",
+    "automation",
+    "oauth"
+  ],
+  "installations": {
+    "http": {
+      "type": "http",
+      "url": "https://app.famulor.io/mcp",
+      "description": "Hosted Streamable HTTP endpoint with browser OAuth",
+      "recommended": true
+    }
+  },
+  "tools": [],
+  "resources": [],
+  "prompts": [],
+  "examples": [],
+  "is_official": true,
+  "is_archived": false
+}


### PR DESCRIPTION
## Summary

Adds Famulor as an official hosted MCP server using Streamable HTTP and browser OAuth.

## Validation

- Confirmed no existing Famulor manifest, issue, or PR
- Verified `https://app.famulor.io/mcp` returns the expected OAuth challenge
- Verified RFC 9728 protected-resource metadata
- Ran `uv run --no-project --with jsonschema python scripts/validate_manifest.py`; Famulor and the full registry passed
- Parsed the new manifest with `jq -e` and ran `git diff --check`

The manifest accurately declares the linked server repository as `Proprietary`; it does not claim an open-source license.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Famulor to the MCP server registry.
  * Included setup details, hosted connection endpoint, licensing, categorization, and service metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->