### PR TITLE
Add Process Street MCP server

### DIFF
--- a/mcp-registry/servers/process-street-mcp.json
+++ b/mcp-registry/servers/process-street-mcp.json
@@ -1,0 +1,36 @@
+{
+  "name": "process-street-mcp",
+  "display_name": "Process Street MCP Server",
+  "description": "Connect AI agents to Process Street workflows, tasks, runs, data sets, and operational records.",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/process-street/process-street-mcp"
+  },
+  "homepage": "https://www.process.st/help/docs/mcp-server/",
+  "author": {
+    "name": "Process Street",
+    "url": "https://www.process.st/"
+  },
+  "license": "[NOT FOUND]",
+  "categories": [
+    "Productivity",
+    "Professional Apps"
+  ],
+  "tags": [
+    "process street",
+    "workflow management",
+    "task management",
+    "business process management",
+    "remote mcp"
+  ],
+  "installations": {
+    "http": {
+      "type": "http",
+      "url": "https://mcp.process.st/",
+      "description": "Connect to the official hosted Streamable HTTP endpoint. Authentication is completed interactively; API-key bearer tokens are supported where documented.",
+      "recommended": true
+    }
+  },
+  "is_official": true,
+  "is_archived": false
+}


### PR DESCRIPTION
## Summary

Add Process Street's official hosted MCP server to the mcpm registry.

## Verification

- Official public repository: https://github.com/process-street/process-street-mcp
- Documentation: https://www.process.st/help/docs/mcp-server/
- Hosted Streamable HTTP endpoint: https://mcp.process.st/
- Official MCP Registry id: `io.github.process-street/process-street-mcp`
- Process Street's public metadata repository does not publish a license, so the required field uses the registry's existing `[NOT FOUND]` convention
- `python scripts/validate_manifest.py` reports `process-street-mcp: Valid`
- Confirmed no existing Process Street entry, issue, or pull request before preparing this change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the Process Street MCP server to the registry.
  * Included server details, categorization, licensing, and repository links.
  * Added an official hosted installation option with interactive authentication and API-key support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->