### PR TITLE
Add Melaya (remote, OAuth 2.1, Android phone + browser control)

### DIFF
--- a/mcp-registry/servers/melaya.json
+++ b/mcp-registry/servers/melaya.json
@@ -1,0 +1,36 @@
+{
+  "name": "melaya",
+  "display_name": "Melaya",
+  "description": "Operate a paired Android phone and browser, and run agent pipelines reaching 6k+ tools, over a single remote OAuth endpoint",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/melaya-labs/melaya-mcp"
+  },
+  "homepage": "https://melaya.org/en/product/mcp",
+  "author": {
+    "name": "Melaya Labs",
+    "url": "https://melaya.org"
+  },
+  "license": "Apache-2.0",
+  "categories": [
+    "System Tools",
+    "AI Systems"
+  ],
+  "tags": [
+    "android",
+    "device control",
+    "browser automation",
+    "agents",
+    "pipelines",
+    "oauth",
+    "accessibility"
+  ],
+  "is_official": true,
+  "installations": {
+    "http": {
+      "type": "http",
+      "url": "https://api.melaya.org/mcp",
+      "description": "Remote streamable HTTP endpoint. Auth is OAuth 2.1 with PKCE and dynamic client registration (RFC 7591), so no API key or environment variables are required: the client registers itself and the user approves scopes in a browser."
+    }
+  }
+}


### PR DESCRIPTION
Adds `mcp-registry/servers/melaya.json`.

Melaya is a remote MCP server that gives an agent hands on a paired Android phone and a paired browser. On the phone it reads the screen through Android's accessibility tree and then taps, types and swipes, so it works inside any app without a per-app integration or a vendor API. It also runs agent pipelines that reach 6k+ tools through connectors.

### Manifest notes

- Uses the `http` installation type, so `url` is set and `command`/`args` are correctly absent per the schema's conditional.
- No `arguments` block, and that is deliberate rather than an omission. Auth is OAuth 2.1 with PKCE and dynamic client registration (RFC 7591), so there is no API key, no token and no environment variable for a user to supply. The client registers itself and the user approves scopes in a browser.
- Categories `System Tools` and `AI Systems`, both from the schema enum.
- `is_official: true`, since this is submitted by Melaya Labs, who run the endpoint.

I checked that `mcp-registry/servers/melaya.json` did not already exist before adding it.

I could not run `scripts/validate_manifest.py` against your checkout from here, so if CI flags anything in the manifest I will fix it straight away.

Repo: https://github.com/melaya-labs/melaya-mcp (Apache-2.0)
Endpoint: https://api.melaya.org/mcp


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Melaya to the MCP server registry.
  - Included server metadata, licensing, categories, tags, and official status.
  - Added links to the project repository and homepage.
  - Added HTTP installation support with OAuth 2.1, PKCE, and dynamic client registration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->