### PR TITLE
Prefer URL client configs over stdio mcpm run

### DIFF
--- a/src/mcpm/clients/managers/vscode.py
+++ b/src/mcpm/clients/managers/vscode.py
@@ -124,7 +124,8 @@ class VSCodeManager(JSONClientManager):
                 "type": "sse" if "/sse" in url.lower() else "http",
                 "url": url,
             }
-            if server_config.headers:
+            # Do not copy credential headers onto cleartext http:// URLs.
+            if server_config.headers and not url.lower().startswith("http://"):
                 result["headers"] = server_config.headers
             return result
         return super().to_client_format(server_config)

--- a/src/mcpm/clients/managers/vscode.py
+++ b/src/mcpm/clients/managers/vscode.py
@@ -99,8 +99,9 @@ class VSCodeManager(JSONClientManager):
         """Convert ServerConfig to VSCode-specific format
 
         VSCode expects a "type" field in addition to command and args.
+        Remote servers use type http/sse plus url/headers — not a model dump.
         """
-        from mcpm.core.schema import STDIOServerConfig
+        from mcpm.core.schema import RemoteServerConfig, STDIOServerConfig
 
         if isinstance(server_config, STDIOServerConfig):
             result = {
@@ -117,6 +118,27 @@ class VSCodeManager(JSONClientManager):
                 result["env"] = non_empty_env
 
             return result
-        else:
-            # For other server types, use the default implementation
-            return super().to_client_format(server_config)
+        if isinstance(server_config, RemoteServerConfig):
+            url = server_config.url or ""
+            result = {
+                "type": "sse" if "/sse" in url.lower() else "http",
+                "url": url,
+            }
+            if server_config.headers:
+                result["headers"] = server_config.headers
+            return result
+        return super().to_client_format(server_config)
+
+    @classmethod
+    def from_client_format(cls, server_name: str, client_config: dict):
+        from mcpm.core.schema import RemoteServerConfig
+
+        cfg = dict(client_config)
+        typ = cfg.pop("type", None)
+        if typ in ("http", "sse") or ("url" in cfg and "command" not in cfg):
+            return RemoteServerConfig(
+                name=server_name,
+                url=cfg.get("url", ""),
+                headers=cfg.get("headers") or {},
+            )
+        return super().from_client_format(server_name, cfg)

--- a/src/mcpm/commands/client.py
+++ b/src/mcpm/commands/client.py
@@ -1138,11 +1138,27 @@ def _replace_client_config_with_profile(client_manager, profile_name, client_nam
         print_error("Error replacing client config with profile", str(e))
 
 
+def _client_config_for_global_server(server_name: str, prefixed_name: str):
+    """Prefer a URL client entry when servers.json already has a URL.
+
+    Stdio `mcpm run` multiplies processes across parallel MCP clients. HTTP/URL
+    servers should be wired as RemoteServerConfig so clients connect directly.
+    """
+    from mcpm.core.schema import RemoteServerConfig, STDIOServerConfig
+
+    global_cfg = global_config_manager.get_server(server_name)
+    if global_cfg is not None and isinstance(global_cfg, RemoteServerConfig):
+        return RemoteServerConfig(
+            name=prefixed_name,
+            url=global_cfg.url,
+            headers=getattr(global_cfg, "headers", {}) or {},
+        )
+    return STDIOServerConfig(name=prefixed_name, command="mcpm", args=["run", server_name])
+
+
 def _replace_client_config_with_mcpm(client_manager, selected_servers, client_name):
     """Replace client config servers with MCPM managed versions."""
     try:
-        from mcpm.core.schema import STDIOServerConfig
-
         # Remove original servers
         for server_name in selected_servers:
             try:
@@ -1153,7 +1169,7 @@ def _replace_client_config_with_mcpm(client_manager, selected_servers, client_na
         # Add MCPM managed versions
         for server_name in selected_servers:
             prefixed_name = f"mcpm_{server_name}"
-            server_config = STDIOServerConfig(name=prefixed_name, command="mcpm", args=["run", server_name])
+            server_config = _client_config_for_global_server(server_name, prefixed_name)
             client_manager.add_server(server_config)
 
         console.print(

--- a/src/mcpm/commands/client.py
+++ b/src/mcpm/commands/client.py
@@ -962,7 +962,7 @@ def import_client(client_name):
 
 def _import_servers_to_global(selected_servers, non_mcpm_servers, client_name):
     """Import selected servers to global configuration."""
-    from mcpm.core.schema import CustomServerConfig, STDIOServerConfig
+    from mcpm.core.schema import CustomServerConfig, RemoteServerConfig, STDIOServerConfig
 
     console.print(f"\n[bold green]Importing {len(selected_servers)} server(s) to global configuration...[/]")
 
@@ -986,6 +986,16 @@ def _import_servers_to_global(selected_servers, non_mcpm_servers, client_name):
 
         try:
             # Extract server configuration
+            if isinstance(server_config, RemoteServerConfig):
+                server_config_obj = RemoteServerConfig(
+                    name=server_name,
+                    url=server_config.url,
+                    headers=server_config.headers or {},
+                )
+                global_config_manager.add_server(server_config_obj)
+                imported_count += 1
+                table.add_row(server_name, server_config.url[:30], "✅ Imported")
+                continue
             if hasattr(server_config, "command"):
                 command = server_config.command
                 args = getattr(server_config, "args", [])

--- a/src/mcpm/commands/client.py
+++ b/src/mcpm/commands/client.py
@@ -852,6 +852,9 @@ def import_client(client_name):
         elif isinstance(server_config, dict):
             command = server_config.get("command", "")
             args = server_config.get("args", [])
+        elif getattr(server_config, "url", None):
+            command = ""
+            args = []
         else:
             continue
 
@@ -862,6 +865,14 @@ def import_client(client_name):
             if len(args) >= 2 and args[0] == "run":
                 is_mcpm_server = True
                 mcpm_servers.append((server_name, args[1]))
+        elif server_name.startswith("mcpm_"):
+            # URL-only generated entries have no `mcpm run` command.
+            url = getattr(server_config, "url", None)
+            if url is None and isinstance(server_config, dict):
+                url = server_config.get("url")
+            if url:
+                is_mcpm_server = True
+                mcpm_servers.append((server_name, server_name[len("mcpm_"):]))
 
         if not is_mcpm_server:
             non_mcpm_servers.append((server_name, server_config))
@@ -981,6 +992,18 @@ def _import_servers_to_global(selected_servers, non_mcpm_servers, client_name):
                 env = getattr(server_config, "env", {})
                 cwd = getattr(server_config, "cwd", None)
             elif isinstance(server_config, dict):
+                if server_config.get("url") and not server_config.get("command"):
+                    from mcpm.core.schema import RemoteServerConfig
+
+                    server_config_obj = RemoteServerConfig(
+                        name=server_name,
+                        url=server_config.get("url", ""),
+                        headers=server_config.get("headers") or {},
+                    )
+                    global_config_manager.add_server(server_config_obj)
+                    imported_count += 1
+                    table.add_row(server_name, server_config.get("url", "")[:30], "✅ Imported")
+                    continue
                 command = server_config.get("command", "")
                 args = server_config.get("args", [])
                 env = server_config.get("env", {})

--- a/tests/test_client_url_replace.py
+++ b/tests/test_client_url_replace.py
@@ -1,0 +1,28 @@
+from unittest.mock import Mock
+
+from mcpm.commands.client import _client_config_for_global_server
+from mcpm.core.schema import RemoteServerConfig, STDIOServerConfig
+
+
+def test_client_config_prefers_remote_url(monkeypatch):
+    remote = RemoteServerConfig(name="gh", url="https://mcp.example/mcp", headers={"A": "b"})
+    monkeypatch.setattr(
+        "mcpm.commands.client.global_config_manager.get_server",
+        Mock(return_value=remote),
+    )
+    cfg = _client_config_for_global_server("gh", "mcpm_gh")
+    assert isinstance(cfg, RemoteServerConfig)
+    assert cfg.name == "mcpm_gh"
+    assert cfg.url == "https://mcp.example/mcp"
+    assert cfg.headers == {"A": "b"}
+
+
+def test_client_config_falls_back_to_stdio_run(monkeypatch):
+    monkeypatch.setattr(
+        "mcpm.commands.client.global_config_manager.get_server",
+        Mock(return_value=STDIOServerConfig(name="local", command="npx", args=["-y", "pkg"])),
+    )
+    cfg = _client_config_for_global_server("local", "mcpm_local")
+    assert isinstance(cfg, STDIOServerConfig)
+    assert cfg.command == "mcpm"
+    assert cfg.args == ["run", "local"]

--- a/tests/test_clients/test_vscode.py
+++ b/tests/test_clients/test_vscode.py
@@ -361,3 +361,17 @@ class TestVSCodeManager:
         assert isinstance(server_config, RemoteServerConfig)
         assert server_config.url == "https://mcp.example/mcp"
         assert server_config.headers["X"] == "1"
+
+
+    def test_to_client_format_remote_omits_headers_on_http(self, vscode_manager):
+        from mcpm.core.schema import RemoteServerConfig
+
+        remote = RemoteServerConfig(
+            name="insecure",
+            url="http://mcp.example/mcp",
+            headers={"Authorization": "Bearer secret"},
+        )
+        vscode_format = vscode_manager.to_client_format(remote)
+        assert vscode_format["type"] == "http"
+        assert vscode_format["url"] == "http://mcp.example/mcp"
+        assert "headers" not in vscode_format

--- a/tests/test_clients/test_vscode.py
+++ b/tests/test_clients/test_vscode.py
@@ -334,3 +334,30 @@ class TestVSCodeManager:
         assert saved_config["servers"]["mcpm_profile_work"]["args"] == ["profile", "run", "work"]
         assert "inputs" in saved_config
         assert isinstance(saved_config["inputs"], list)
+
+
+    def test_to_client_format_remote(self, vscode_manager):
+        from mcpm.core.schema import RemoteServerConfig
+
+        remote = RemoteServerConfig(
+            name="remote-http",
+            url="https://mcp.example/mcp",
+            headers={"Authorization": "Bearer x"},
+        )
+        vscode_format = vscode_manager.to_client_format(remote)
+        assert vscode_format["type"] == "http"
+        assert vscode_format["url"] == "https://mcp.example/mcp"
+        assert vscode_format["headers"]["Authorization"] == "Bearer x"
+        assert "name" not in vscode_format
+        assert "command" not in vscode_format
+
+    def test_from_client_format_remote(self, vscode_manager):
+        from mcpm.core.schema import RemoteServerConfig
+
+        server_config = vscode_manager.from_client_format(
+            "remote-http",
+            {"type": "http", "url": "https://mcp.example/mcp", "headers": {"X": "1"}},
+        )
+        assert isinstance(server_config, RemoteServerConfig)
+        assert server_config.url == "https://mcp.example/mcp"
+        assert server_config.headers["X"] == "1"


### PR DESCRIPTION
Fixes #371. Fixes #362. When servers.json already has a URL, write RemoteServerConfig into client configs instead of spawning stdio mcpm run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * URL-based server configurations are now supported directly in VSCode, including HTTP and SSE connections.
  * Connection URLs, headers, and transport types are preserved when importing or exporting VSCode server settings.

* **Bug Fixes**
  * Global server configurations using a URL now connect directly to the configured remote server.
  * Server connection headers are correctly applied to URL-based servers.
  * Credential-bearing headers are omitted for cleartext HTTP connections.
  * Server configurations without a URL continue to run through the local server command.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->