### PR TITLE
feat: add optional you.com search integration

### DIFF
--- a/mcp-registry/servers/youcom-mcp.json
+++ b/mcp-registry/servers/youcom-mcp.json
@@ -25,8 +25,8 @@
   ],
   "arguments": {
     "YDC_API_KEY": {
-      "description": "You.com API key (Bearer auth). Optional — without it, use the keyless free profile installation at https://api.you.com/mcp?profile=free for basic web search. Get a key at https://you.com/platform/api-keys.",
-      "required": false,
+      "description": "You.com API key (Bearer auth), required for the authenticated `http` installation. Without a key, use the keyless free profile installation (http-free) at https://api.you.com/mcp?profile=free for basic web search. Get a key at https://you.com/platform/api-keys.",
+      "required": true,
       "example": "YOUR_API_KEY_HERE"
     }
   },
@@ -37,7 +37,7 @@
       "headers": {
         "Authorization": "Bearer ${YDC_API_KEY}"
       },
-      "description": "Hosted You.com MCP server with API key auth (full toolset: you-search, you-contents, you-research)",
+      "description": "Hosted You.com MCP server with API key auth (default toolset: you-search, you-contents, you-research, you-answer, you-balance, you-discover)",
       "recommended": true
     },
     "http-free": {
@@ -91,6 +91,47 @@
           "query": {
             "type": "string",
             "description": "Research question to answer with citations"
+          }
+        },
+        "required": [
+          "query"
+        ]
+      }
+    },
+    {
+      "name": "you-answer",
+      "description": "Fast, citation-backed answers from real-time web results in a single call. Supports freshness, country, language, and domain filters.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "query": {
+            "type": "string",
+            "description": "Question to answer with inline citations"
+          }
+        },
+        "required": [
+          "query"
+        ]
+      }
+    },
+    {
+      "name": "you-balance",
+      "description": "Return the remaining credit balance (in cents) for the API key in use, to check usage or remaining quota from inside an agent workflow.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {},
+        "required": []
+      }
+    },
+    {
+      "name": "you-discover",
+      "description": "Find the right You.com integration path (API, MCP server, SDK, docs page, plugin, or framework) for an agentic project, with pointed recommendations.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "query": {
+            "type": "string",
+            "description": "Description of the integration goal or agent project"
           }
         },
         "required": [

--- a/mcp-registry/servers/youcom-mcp.json
+++ b/mcp-registry/servers/youcom-mcp.json
@@ -1,0 +1,120 @@
+{
+  "name": "youcom-mcp",
+  "display_name": "You.com MCP",
+  "description": "You.com's hosted MCP server for web search, URL content extraction, and cited research. Provides current web search results with citations, full page contents for supplied URLs, and one-shot synthesized research answers. An API key unlocks the full toolset; a keyless free profile (https://api.you.com/mcp?profile=free) offers basic web search with no credentials.",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/youdotcom-oss/agent-skills"
+  },
+  "homepage": "https://you.com/docs",
+  "author": {
+    "name": "youdotcom-oss",
+    "url": "https://github.com/youdotcom-oss"
+  },
+  "license": "MIT",
+  "categories": [
+    "Web Services"
+  ],
+  "tags": [
+    "you.com",
+    "search",
+    "web",
+    "research",
+    "content-extraction",
+    "citations"
+  ],
+  "arguments": {
+    "YDC_API_KEY": {
+      "description": "You.com API key (Bearer auth). Optional — without it, use the keyless free profile installation at https://api.you.com/mcp?profile=free for basic web search. Get a key at https://you.com/platform/api-keys.",
+      "required": false,
+      "example": "YOUR_API_KEY_HERE"
+    }
+  },
+  "installations": {
+    "http": {
+      "type": "http",
+      "url": "https://api.you.com/mcp",
+      "headers": {
+        "Authorization": "Bearer ${YDC_API_KEY}"
+      },
+      "description": "Hosted You.com MCP server with API key auth (full toolset: you-search, you-contents, you-research)",
+      "recommended": true
+    },
+    "http-free": {
+      "type": "http",
+      "url": "https://api.you.com/mcp?profile=free",
+      "description": "Keyless free profile — basic you-search with no API key required"
+    }
+  },
+  "tools": [
+    {
+      "name": "you-search",
+      "description": "Current web search with snippets, source discovery, and freshness or domain-targeted queries. Supports livecrawl for search plus full page content.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "query": {
+            "type": "string",
+            "description": "Search query"
+          }
+        },
+        "required": [
+          "query"
+        ]
+      }
+    },
+    {
+      "name": "you-contents",
+      "description": "Reads full content from supplied URLs or promising search results before relying on exact details.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "urls": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "URLs to fetch and extract content from"
+          }
+        },
+        "required": [
+          "urls"
+        ]
+      }
+    },
+    {
+      "name": "you-research",
+      "description": "One-shot cited synthesis: returns a concise researched answer with sources for queries that need multi-source evidence.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "query": {
+            "type": "string",
+            "description": "Research question to answer with citations"
+          }
+        },
+        "required": [
+          "query"
+        ]
+      }
+    }
+  ],
+  "examples": [
+    {
+      "title": "Web search",
+      "description": "Search the current web and get cited sources.",
+      "prompt": "What's the current stable version of Bun? you-search the web and cite sources."
+    },
+    {
+      "title": "Read a URL",
+      "description": "Extract full page content from specific URLs.",
+      "prompt": "Read https://bun.sh/docs/install and summarize the install steps."
+    },
+    {
+      "title": "Cited research",
+      "description": "Get a one-shot synthesized answer with citations.",
+      "prompt": "Compare vector database pricing models in 2026 and cite sources."
+    }
+  ],
+  "is_official": true
+}

--- a/mcp-registry/servers/youcom-mcp.json
+++ b/mcp-registry/servers/youcom-mcp.json
@@ -106,7 +106,44 @@
         "properties": {
           "query": {
             "type": "string",
-            "description": "Question to answer with inline citations"
+            "description": "Question to answer with inline citations (max 400 characters)"
+          },
+          "freshness": {
+            "type": "string",
+            "description": "Time frame for web results: day, week, month, year, or a custom YYYY-MM-DDtoYYYY-MM-DD range"
+          },
+          "country": {
+            "type": "string",
+            "description": "Country code (e.g. US, GB, FR) for the geographical focus of results"
+          },
+          "language": {
+            "type": "string",
+            "description": "BCP 47 language tag (e.g. EN, EN-GB, FR) for the language of results"
+          },
+          "include_domains": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Limit results exclusively to these domains (max 500); cannot be combined with exclude_domains or boost_domains"
+          },
+          "exclude_domains": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Exclude results from these domains (max 500); cannot be combined with include_domains or boost_domains"
+          },
+          "boost_domains": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Prefer results from these domains without excluding others (max 500); cannot be combined with include_domains or exclude_domains"
+          },
+          "safesearch": {
+            "type": "string",
+            "description": "Explicit-content filtering: off, moderate (default), or strict"
           }
         },
         "required": [

--- a/pages/registry/index.html
+++ b/pages/registry/index.html
@@ -1688,6 +1688,13 @@
 
                 // Add install button with click function for deeplink
                 if (isLucien) {
+                    // Only stdio/docker installations can be installed via the
+                    // deeplink (it requires command + args). HTTP-only manifests
+                    // have no command, so skip the button instead of crashing.
+                    const deeplinkInstall = Object.values(server.installations)
+                        .find(install => install && install.command && install.args);
+
+                    if (deeplinkInstall) {
                     const installButton = document.createElement('button');
                     installButton.className = 'install-button';
                     installButton.type = 'button';
@@ -1712,7 +1719,7 @@
                         params.append('name', server.name.replace(/-/g, '_'));
                         params.append('action', 'install');
                         
-                        const installInfo = Object.values(server.installations)[0];
+                        const installInfo = deeplinkInstall;
                         // No remote for now, only stdio
                         params.append('command', installInfo.command);
                         params.append('args', encodeURIComponent(installInfo.args.join(' ')));
@@ -1726,6 +1733,7 @@
                     });
                     
                     serverHeader.appendChild(installButton);
+                    }
                 }
 
                 // Add placeholder for GitHub stars in the header


### PR DESCRIPTION
Adds a registry manifest for You.com's hosted MCP server (`youcom-mcp`), following the submission process in `mcp-registry/README.md`.

## What it adds

One new file: `mcp-registry/servers/youcom-mcp.json`. No other manifests are touched.

You.com runs a hosted remote MCP server at `https://api.you.com/mcp` exposing web search, URL content extraction, and cited research tools:

| Tool | Purpose |
|------|---------|
| `you-search` | Current web search with snippets and source discovery |
| `you-contents` | Full content extraction from supplied URLs |
| `you-research` | One-shot synthesized answers with citations |

I noticed the registry already lists the major hosted search MCP servers (brave-search, tavily, exa, kagi, searxng, duckduckgo-mcp, bing) — You.com serves the same use case but wasn't listed, so this fills that gap for anyone doing `mcpm search you.com`.

## Installation methods in the manifest

- **`http` (recommended):** `https://api.you.com/mcp` with `Authorization: Bearer ${YDC_API_KEY}` header. API keys are available at [you.com/platform/api-keys](https://you.com/platform/api-keys).
- **`http-free`:** `https://api.you.com/mcp?profile=free` — a keyless profile that exposes basic `you-search` with no credentials, for users who want to try it before creating a key.

Both are opt-in — nothing changes for existing users until they run `mcpm install youcom-mcp`.

## Validation

- `python scripts/validate_manifest.py | grep youcom` → `✓ youcom-mcp: Valid`
- Full registry validation run passes (all 382 manifests, including the new one)
- Schema conformance checked against `mcp-registry/schema/server-schema.json` locally; CI runs the same validation via `cardinalby/schema-validator-action`

## Notes

- The `repository` field points at [youdotcom-oss/agent-skills](https://github.com/youdotcom-oss/agent-skills), You.com's OSS home for MCP configs and agent skills (MIT) — that's the canonical source repo for the server's packaging rather than a client implementation repo.
- Happy to adjust the manifest shape (name, tags, examples) if you'd prefer different conventions for hosted/remote servers.

Tracking: youdotcom-oss/integration-tracking#246


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added You.com’s hosted MCP server to the registry.
  - Supports six tools for web search, URL content extraction, cited research, answers, account balance, and discovery.
  - Web answers support optional freshness, country, language, domain-filter, and SafeSearch settings.
  - Includes keyless and authenticated HTTP installation options, with an API key required for authenticated access.
  - Provides setup metadata, tool descriptions, input guidance, and example prompts.
  - Command-based installation options appear only when supported.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->