### PR TITLE
feat: add ParlayAPI MCP server manifest

### DIFF
--- a/mcp-registry/servers/parlayapi.json
+++ b/mcp-registry/servers/parlayapi.json
@@ -1,0 +1,59 @@
+{
+  "name": "parlayapi",
+  "display_name": "ParlayAPI",
+  "description": "Sports odds tools for personal and internal research. Public discovery works without a key; authenticated data uses your own ParlayAPI account. Also exposes account signup, login-email, checkout-link and saved-book-preference tools; these should only be invoked at the user's request.",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/JacobiusMakes/parlay-api-mcp"
+  },
+  "homepage": "https://parlay-api.com/mcp",
+  "author": {
+    "name": "JacobiusMakes",
+    "url": "https://github.com/JacobiusMakes"
+  },
+  "license": "MIT",
+  "categories": [
+    "Analytics",
+    "Web Services"
+  ],
+  "tags": [
+    "sports",
+    "odds",
+    "personal-research"
+  ],
+  "installations": {
+    "uvx-preview": {
+      "type": "uvx",
+      "command": "uvx",
+      "args": [
+        "parlayapi-mcp==0.3.5"
+      ],
+      "recommended": true,
+      "description": "Keyless discovery and public previews. Requires uv. Add your own account key later to use authenticated data."
+    },
+    "uvx-personal-account": {
+      "type": "uvx",
+      "command": "uvx",
+      "args": [
+        "parlayapi-mcp==0.3.5"
+      ],
+      "env": {
+        "PARLAYAPI_KEY": "${PARLAYAPI_KEY}"
+      },
+      "description": "Authenticated data for your own ParlayAPI account. Requires uv and your own API key."
+    }
+  },
+  "arguments": {
+    "PARLAYAPI_KEY": {
+      "description": "Your own ParlayAPI account key. Required only for the personal-account installation option; the recommended preview option does not request a key. Do not share this value.",
+      "required": true
+    }
+  },
+  "examples": [
+    {
+      "title": "Inspect current access options",
+      "description": "Read public pricing and coverage information before configuring an account.",
+      "prompt": "Use ParlayAPI to inspect current pricing and book coverage. Do not create an account, send an email or change preferences."
+    }
+  ]
+}

--- a/mcp-registry/servers/parlayapi.json
+++ b/mcp-registry/servers/parlayapi.json
@@ -22,11 +22,11 @@
     "personal-research"
   ],
   "installations": {
-    "uvx-preview": {
+    "uvx": {
       "type": "uvx",
       "command": "uvx",
       "args": [
-        "parlayapi-mcp==0.3.5"
+        "parlayapi-mcp@0.3.5"
       ],
       "recommended": true,
       "description": "Keyless discovery and public previews. Requires uv. Configure your own account key later in your private MCP client settings for authenticated data."

--- a/mcp-registry/servers/parlayapi.json
+++ b/mcp-registry/servers/parlayapi.json
@@ -26,7 +26,7 @@
       "type": "uvx",
       "command": "uvx",
       "args": [
-        "parlayapi-mcp@0.3.5"
+        "parlayapi-mcp@0.3.6"
       ],
       "recommended": true,
       "description": "Keyless discovery and public previews. Requires uv. Configure your own account key later in your private MCP client settings for authenticated data."

--- a/mcp-registry/servers/parlayapi.json
+++ b/mcp-registry/servers/parlayapi.json
@@ -1,7 +1,7 @@
 {
   "name": "parlayapi",
   "display_name": "ParlayAPI",
-  "description": "Sports odds tools for personal and internal research. Public discovery works without a key; authenticated data uses your own ParlayAPI account. Also exposes account signup, login-email, checkout-link and saved-book-preference tools; these should only be invoked at the user's request.",
+  "description": "Sports odds tools for personal and internal research. Public discovery works without a key; configure your own ParlayAPI key later in private MCP client settings for authenticated data. Also exposes account signup, login-email, checkout-link and saved-book-preference tools; invoke those only at the user's request.",
   "repository": {
     "type": "git",
     "url": "https://github.com/JacobiusMakes/parlay-api-mcp"
@@ -29,24 +29,7 @@
         "parlayapi-mcp==0.3.5"
       ],
       "recommended": true,
-      "description": "Keyless discovery and public previews. Requires uv. Add your own account key later to use authenticated data."
-    },
-    "uvx-personal-account": {
-      "type": "uvx",
-      "command": "uvx",
-      "args": [
-        "parlayapi-mcp==0.3.5"
-      ],
-      "env": {
-        "PARLAYAPI_KEY": "${PARLAYAPI_KEY}"
-      },
-      "description": "Authenticated data for your own ParlayAPI account. Requires uv and your own API key."
-    }
-  },
-  "arguments": {
-    "PARLAYAPI_KEY": {
-      "description": "Your own ParlayAPI account key. Required only for the personal-account installation option; the recommended preview option does not request a key. Do not share this value.",
-      "required": true
+      "description": "Keyless discovery and public previews. Requires uv. Configure your own account key later in your private MCP client settings for authenticated data."
     }
   },
   "examples": [


### PR DESCRIPTION
Adds ParlayAPI to the installable MCP registry for personal and internal sports-odds research. The single recommended UVX installation pins `parlayapi-mcp==0.3.5` and starts without prompting for credentials. Users who need authenticated data configure their own key later in private MCP client settings.

The entry discloses its signup, login-email, checkout-link and saved-book-preference tools. Its example requests public pricing and coverage information and excludes account and preference actions. This is an owner-submitted, AI-assisted draft pending final review.

Validation: the upstream `scripts/validate_manifest.py` passes all 382 manifests; `git diff --check` passes. The actual selected-method variable extractor returns no referenced arguments for this installation, and the manifest has no credential arguments or environment templates. No authenticated API request, signup, email operation or native client installation was performed.

Source: https://github.com/JacobiusMakes/parlay-api-mcp and https://pypi.org/project/parlayapi-mcp/0.3.5/ .


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the ParlayAPI MCP server to the registry.
  - Included metadata, categories, an example prompt, and `uvx` installation guidance for version 0.3.6.
  - Documented keyless public discovery and optional private-key configuration for authenticated data.
  - Clarified that account, checkout, login-email, and saved-preference actions require explicit user requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
The `uvx` method uses `parlayapi-mcp@0.3.5`, which the MCPM source parser recognizes. Both this command and the explicit `--from parlayapi-mcp==0.3.5 parlayapi-mcp` form were launched successfully: package 0.3.5, initialize and 22-tool discovery, no keys or API/tool calls, and process cleanup.
