### PR TITLE
Add SHAR Production Metadata MCP registry entry

### DIFF
--- a/mcp-registry/servers/shar-production-metadata-mcp.json
+++ b/mcp-registry/servers/shar-production-metadata-mcp.json
@@ -1,0 +1,44 @@
+{
+  "name": "shar-production-metadata-mcp",
+  "display_name": "SHAR Production Metadata MCP",
+  "description": "Read-only MCP server that validates rights-aware production metadata manifests. It checks required project metadata, production stage, and declared rights status, returning a releasability result without reading files, calling networks, or publishing data.",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/SHARProduction/production-metadata-mcp"
+  },
+  "homepage": "https://sharprod.com/",
+  "author": {
+    "name": "SHAR Production",
+    "url": "https://sharprod.com/"
+  },
+  "license": "MIT",
+  "categories": ["Media Creation", "AI Systems", "MCP Tools"],
+  "tags": ["production-metadata", "rights-aware", "metadata-validation", "video-production", "read-only"],
+  "installations": {
+    "git-clone": {
+      "type": "custom",
+      "command": "node",
+      "args": ["server.js"],
+      "description": "Clone https://github.com/SHARProduction/production-metadata-mcp, run npm ci, then run node server.js from the clone.",
+      "recommended": true
+    }
+  },
+  "tools": [
+    {
+      "name": "validate_production_manifest",
+      "description": "Validates project metadata, production stage, and declared rights status in a manifest object, returning a releasability result and validation errors.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "manifest": {
+            "type": "object",
+            "description": "Production metadata manifest to validate."
+          }
+        },
+        "required": ["manifest"]
+      }
+    }
+  ],
+  "is_official": true,
+  "is_archived": false
+}

--- a/mcp-registry/servers/shar-production-metadata-mcp.json
+++ b/mcp-registry/servers/shar-production-metadata-mcp.json
@@ -17,9 +17,13 @@
   "installations": {
     "git-clone": {
       "type": "custom",
-      "command": "node",
-      "args": ["server.js"],
-      "description": "Clone https://github.com/SHARProduction/production-metadata-mcp, run npm ci, then run node server.js from the clone.",
+      "command": "npx",
+      "args": [
+        "--yes",
+        "--package=git+https://github.com/SHARProduction/production-metadata-mcp.git#4d15a752948ba841ea565998d870bfae33d2b9d2",
+        "production-metadata-mcp"
+      ],
+      "description": "Runs the pinned public Git source through npm exec. Requires Node.js 20+ and Git; the package installs from commit 4d15a752948ba841ea565998d870bfae33d2b9d2 and starts its declared production-metadata-mcp binary.",
       "recommended": true
     }
   },


### PR DESCRIPTION
Adds one source-backed entry for SHAR Production Metadata MCP v1.0.4. The entry uses the actual public Git source and a truthful clone/npm-ci/node-server.js install path, rather than claiming an unpublished npm package. The validator reports this entry as valid; its overall exit is nonzero due two existing cp1251 decoding failures in unrelated upstream files (baidumap and mcp-server-weibo).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the `shar-production-metadata-mcp` server to the registry.
  * Provides read-only validation of rights-aware production metadata manifests.
  * Includes the `validate_production_manifest` tool, which accepts a manifest and returns a releasability result.
  * Added installation guidance, including Node.js 20+ and Git requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->